### PR TITLE
design system: SSoT基盤を構築 (DESIGN.md + tokens + gap report)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,21 @@
+# portfolio-v4 プロジェクト規約
+
+## デザインシステム — SSoT は `DESIGN.md`
+
+UI / トークン / コピー / アイコノグラフィに関する変更は、必ずリポジトリ root の `DESIGN.md` を参照すること。`DESIGN.md` がアフロ Design System の Single Source of Truth。
+
+### 必須ルール（DESIGN.md から派生）
+
+- **カラー**: 任意の hex を直書きしない。`styles/tokens.css` のセマンティックエイリアス（`--surface-*` / `--text-*` / `--border-*` / `--action-*`）または Tailwind の対応クラス（`bg-paper`, `text-primary` 等）を使う。
+- **影**: ソフト/ブラー影は禁止（`shadow-sm/md/lg/xl/2xl` 等）。許容は `--shadow-hard`（4px 4px 0 0 インク、ぼかしなし）のみ、インタラクティブカードの hover に限る。
+- **グラデーション禁止**。
+- **角丸は 0–6px**。`rounded-pill`（999px）はタグ・アバターのみ。`rounded-lg/2xl/3xl/full` を一般 UI に使わない。
+- **タイポ**: 見出し = Space Grotesk、本文 = DM Sans、JP = Noto Sans JP、mono ラベルは大文字 + 0.16em tracking。
+- **Emoji 禁止**（UI / コピー / コメント全てで）。状態は Badge / ドットで表す。
+- **リンク色**: `--hazard #BB6A35` のみ。それ以外の色（blue 等）でリンクを描画しない。
+- **余白**: セクション縦リズム 64–128px。ぎゅっと詰めない。
+- **Voice**: 一人称・単数 "I"。マーケ語（leverage / synergy / best-in-class）禁止。誇張・感嘆禁止。
+
+### 乖離の扱い
+
+既存コードと `DESIGN.md` の乖離は `docs/design-gap.md` に集約。新規実装・リファクタ時はここを潰す方向で進める。

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,196 @@
+# アフロ Design System — DESIGN.md
+
+**金城将太郎（アフロ / Kinjo Shotaro）** のパーソナルブランド・デザインシステム。
+小さく鋭い SaaS プロダクトを複数手がけるフルスタックエンジニア。TypeScript / React / Next.js。
+キーボードを離れれば、ランエボ・スキー・旅。
+
+> 素材は **アスファルト・コンクリート・紙**。静かで、工業的で、控えめ。
+> 路面と紙のような手触り、彩度はほぼゼロ、余白はたっぷり、角丸は最小。
+> **グラデーションも影も使わない。** 自信は声量ではなく、抑制で示す。
+
+---
+
+## 1. ブランドの基本（Content Fundamentals）
+
+| 項目 | 指針 |
+|---|---|
+| **Voice** | 一人称・単数。"I build SaaS." 顔の見えない "we" ではなく、常に人がいるパーソナルブランド。 |
+| **Tone** | 静かな自信、控えめ。事実を淡々と述べ、そのまま立たせる。誇張も感嘆もしない。 |
+| **Casing** | 見出し・本文はセンテンスケース。**大文字は mono のマイクロラベルだけ**（アイブロウ、メタ情報、スペックキー、フッター）。そこでは 0.16em のワイドトラッキング。 |
+| **Brevity** | 短文。リズムのための体言止め・断片も可。形容詞は2つ目を削る。 |
+| **Bilingual** | 日本語は英語と自然に同居（ワードマーク「アフロ」、タグ「ランエボ・スキー・旅」、日本語読者向けの本文）。装飾としてではなく、意味を持つ場所にだけ。 |
+| **Numbers** | 控えめな証拠として少数の正直な数字（"5 products shipped", "100% TypeScript"）。虚栄の指標の壁は作らない。 |
+| **Emoji** | 使わない。プロダクトでもコピーでも。状態は Badge とドットで表す。 |
+| **Vocabulary** | 素朴な職人言葉 — "ship", "build", "the line", "stack"。マーケ語（leverage / synergy / best-in-class）は避ける。 |
+
+ヒーローコピー例：
+*"Kinjo Shotaro — full-stack engineer shipping a handful of small, sharp SaaS products.
+TypeScript front to back. Off the keyboard: a Lancer Evolution, spring corn snow, and a one-way ticket somewhere."*
+
+---
+
+## 2. カラー（Color）
+
+彩度ほぼゼロの暖色ニュートラル。**フラットのみ、グラデーション禁止。**
+
+### 2.1 素材アンカー
+| トークン | 値 | 役割 |
+|---|---|---|
+| `--asphalt` | `#302F2C` | 暗いサーフェス / 主インク |
+| `--concrete` | `#8A8680` | 中間点 — 二次テキスト、ボーダー、ディバイダー |
+| `--paper` | `#EFEDE3` | 明るいサーフェス / 紙のストック |
+
+### 2.2 ニュートラル・ランプ（暖色・低彩度 16 段）
+`--neutral-950 #1B1A18` → `--neutral-900` → `--neutral-850` → **`--neutral-800 #302F2C`（= ASPHALT）** →
+`--neutral-700` → `--neutral-600` → `--neutral-500` → **`--neutral-450 #8A8680`（= CONCRETE）** →
+`--neutral-400` → `--neutral-300` → `--neutral-250` → `--neutral-200` → `--neutral-150` →
+**`--neutral-100 #EFEDE3`（= PAPER）** → `--neutral-50` → `--neutral-0 #FAF8F0`
+
+> ランプの値は**塗り**に使う。コンポーネントでは**セマンティックエイリアス**を参照する。
+
+### 2.3 シグナルトーン（控えめに、低彩度のまま）
+| トークン | 値 | 意味 |
+|---|---|---|
+| `--signal-positive` | `#5C6E54` | lichen green |
+| `--signal-caution` | `#9C7B3F` | ochre / desaturated hazard |
+| `--signal-critical` | `#92503F` | oxide rust-red |
+| `--signal-info` | `#4F6470` | slate blue |
+
+主に Badge の輪郭やステータスドットとして。塗りとして使うのは稀。
+
+### 2.4 アクセント — Hazard（リンクとホバー専用）
+| トークン | 値 | 用途 |
+|---|---|---|
+| `--hazard` / `--accent` / `--link` | `#BB6A35` | 焦げた琥珀。**インラインリンク、nav リンクのホバー、カード矢印のホバー、フッターリンクのホバーのみ。** |
+| `--hazard-deep` / `--accent-hover` | `#A85A2B` | ホバー / プレス |
+| （Asphalt 文脈） | `#CF8348` / `#DD9358` | 暗背景では可読性のため少し持ち上げる |
+
+> Primary ボタン・タブ・選択チップは**インク（asphalt）のまま**。アクセントが主役（うるさい要素）にならないようにする。
+
+### 2.5 セマンティックエイリアス（コンポーネントで使う）
+- **サーフェス**: `--surface-page` / `--surface-raised` / `--surface-sunken` / `--surface-card` / `--surface-inverse`
+- **テキスト**: `--text-primary` / `--text-secondary` / `--text-tertiary` / `--text-disabled` / `--text-on-inverse`
+- **ボーダー**: `--border-strong`（CONCRETE）/ `--border-default` / `--border-subtle` / `--divider`
+- **アクション**: `--action-primary-*`（インク on 紙）/ `--action-secondary-*` / `--action-ghost-*` / `--focus-ring`
+
+### 2.6 2つの文脈（Surface contexts）
+- 既定の **Paper（明）** と **Asphalt（暗）** の2文脈。`data-theme="asphalt"` で切り替え。
+- 同じトークン名で値だけ反転。フッターや反転パネルに使用。
+
+---
+
+## 3. タイポグラフィ（Type）
+
+| ロール | フォント | 設定 |
+|---|---|---|
+| **Display / Headings** | `--font-display` = **Space Grotesk** (500–700) | 大サイズで letter-spacing −0.02〜−0.03em、センテンスケース |
+| **Body / UI** | `--font-body` = **DM Sans** (400–600) | line-height 1.5（UI）〜 1.7（prose） |
+| **Mono / Labels / Code** | `--font-mono` = システム mono スタック（webfont なし） | アイブロウ・メタ・スペックキー。大文字 + 0.16em |
+| **Japanese** | `--font-jp` = **Noto Sans JP** (400/500/700) | 全ファミリーのフォールバックに含み、JP と Latin を綺麗に同居 |
+
+### 3.1 スケール（1.250 major-third, 11px → 88px）
+`--size-3xs 11px`（micro）/ `--size-2xs 12px` / `--size-xs 13px` / `--size-sm 14px` /
+`--size-md 16px`（base body）/ `--size-lg 18px` / `--size-xl 22px`（H4）/ `--size-2xl 28px`（H3）/
+`--size-3xl 36px`（H2）/ `--size-4xl 48px`（H1）/ `--size-5xl 64px`（display）/ `--size-6xl 88px`（hero）
+
+> 本文の最小は 16px、マイクロラベルは 11–12px。
+
+### 3.2 行間・字間
+- Line-height: `--leading-tight 1.05` / `--leading-snug 1.18` / `--leading-normal 1.5` / `--leading-relaxed 1.7`
+- Tracking: `--tracking-tight −0.02em` / `--tracking-snug −0.01em` / `--tracking-wide 0.08em` / `--tracking-wider 0.16em`
+
+### 3.3 合成ロール
+`--text-display` / `--text-h1` / `--text-h2` / `--text-h3` / `--text-body-lg` / `--text-body` / `--text-mono`
+
+---
+
+## 4. スペーシング & レイアウト（Spacing & Layout）
+
+たっぷりの余白が署名。セクションは呼吸する（縦リズム 64–128px）。
+
+- **スケール**（4px base, 8px rhythm）: `--space-1 4` / `-2 8` / `-3 12` / `-4 16` / `-5 24` / `-6 32` / `-7 48` / `-8 64` / `-9 96` / `-10 128` / `-11 192`
+- **コンテナ**: `--container-prose 68ch` / `--container-narrow 720px` / `--container-content 1080px` / `--container-wide 1320px` / `--gutter = --space-5`
+- インラインフローではなく **flex / grid + `gap`** を全面採用。
+
+---
+
+## 5. ボーダー・角丸・深度（Borders, Radius, Depth）
+
+- **角丸は最小（0–6px）**: `--radius-xs 2` / `-sm 3` / `--radius-md 4`（コントロール・カード既定）/ `-lg 6` / `--radius-pill 999`（タグ・アバターのみ）。スクエアで工業的。
+- **ボーダーが構造を担う**: 既定 1px ハードライン `--border-default`、強調に CONCRETE `--border-strong`、エディトリアルな区切り・選択状態に 2–3px のインク罫（`--border-thick 2` / `--border-rule 3`）。
+- **影は使わない。** 深度はボーダー・サーフェスのコントラスト・余白から。唯一許される持ち上げは、フラットな**ハードオフセット** `--shadow-hard: 4px 4px 0 0` インク（ぼかしなし）。インタラクティブなカードのホバーのみ。ソフト/ブラー影は禁止。
+
+---
+
+## 6. モーション（Motion）
+
+- 抑制的。**120–320ms**、`--ease-standard cubic-bezier(0.2,0,0.2,1)`。
+- バウンスなし、スプリングなし、無限ループなし。
+- ホバー = 色 / ボーダーのシフト。プレス = 1px 下に translate。タブの下線は左からスケールイン。
+- `prefers-reduced-motion` を尊重。
+- トークン: `--duration-fast 120ms` / `--duration-normal 200ms` / `--duration-slow 320ms` / `--ease-standard` / `--ease-out`
+
+---
+
+## 7. アイコノグラフィ（Iconography）
+
+- **システム**: [Lucide](https://lucide.dev) — 細い **1.5px** ストローク、スクエアな linecap、24×24 グリッド。機械的で抑制された線質が工業的なトーンに合う。CDN（`unpkg.com/lucide`）から読み込み、レンダー後に `lucide.createIcons()` を呼ぶ。`currentColor` を継承。
+- **代替フラグ**: Lucide は「選んだ」マッチであり既存のブランド資産ではない。別セットに差し替えても可 — 細く・スクエアな・モノラインの性格を保つこと。
+- **Emoji**: アイコンにもコピーにも一切使わない。
+- **Unicode**: アイコノグラフィに使わない。状態は Lucide グリフか Badge ドットで。
+- 共通セット: ski / car / travel / build / ship / stack / link / status（`guidelines/iconography.card.html`）。
+
+---
+
+## 8. コンポーネント（Components）
+
+ロード後、各コンポーネントは `window.DesignSystem_83d653` に公開される。
+
+```html
+<link rel="stylesheet" href="_ds/<folder>/tokens/fonts.css">
+<link rel="stylesheet" href="_ds/<folder>/tokens/colors.css">
+<link rel="stylesheet" href="_ds/<folder>/tokens/typography.css">
+<link rel="stylesheet" href="_ds/<folder>/tokens/spacing.css">
+<link rel="stylesheet" href="_ds/<folder>/tokens/base.css">
+<link rel="stylesheet" href="_ds/<folder>/styles.css">
+<script src="_ds/<folder>/_ds_bundle.js"></script>
+```
+
+`window.React` / `window.ReactDOM` を先に読み込むこと。バンドルは通常の `<script>`（`type="text/babel"` も `module` も不要）。
+
+| コンポーネント | 説明 | 例 |
+|---|---|---|
+| **Button** | ブランドの主アクション。インク on 紙、スクエア、影なし。`variant`: primary / secondary、`size`: sm 等 | `<Button variant="primary">Ship it</Button>` |
+| **IconButton** | ラベルなしの正方形アクション（ツールバー） | `<IconButton aria-label="Close"><X /></IconButton>` |
+| **Input** | ラベル・ヒント・アイコン・エラー状態付き 1 行テキスト | `<Input label="Email" type="email" required />` |
+| **Switch** | バイナリ on/off。スクエアなトラック、紙のサム | `<Switch label="Dark surface" defaultChecked />` |
+| **Card** (+ `Card.Body`) | ボーダー付きサーフェス。静止時は影なし、任意のハードオフセット lift。`interactive` / `lift` / `rule` | `<Card><h3>Ran Evo</h3></Card>` |
+| **Badge** | 小さなステータス / カテゴリマーカー。mono、大文字、スクエア。`variant`: solid / positive…、`dot` | `<Badge variant="positive" dot>Live</Badge>` |
+| **Tag** | フィルタ・キーワード用ピル。選択可・削除可 | `<Tag active onClick={toggle}>React</Tag>` |
+| **Tabs** | 水平セクション切替。underline / enclosed（pill） | `<Tabs value={tab} onChange={setTab} … />` |
+
+```jsx
+const { Button, Card, Badge, Tag, Tabs, Input, Switch, IconButton } = window.DesignSystem_83d653;
+```
+
+### カードのバリエーション
+- 既定: `--surface-card` + 1px `--border-default`、4px 角丸、静止時影なし。
+- `interactive`: ホバーで CONCRETE ボーダー。
+- `lift`: ホバーでハードオフセット影。
+- `rule`: 全周ボーダーを 1 本の重いインク上罫に差し替え（エディトリアル）。
+
+---
+
+## 9. UI キット & 参照
+
+- `ui_kits/portfolio/` — アフロのパーソナル SaaS ポートフォリオ（hero / work grid / project detail / writing / about + contact）。クリックスルー可、上記コンポーネントを構成。
+- `guidelines/*.card.html` — Colors / Type / Spacing / Brand の仕様カード（Design System タブ）。
+- ワードマークは純粋にタイポグラフィ的 — ロゴマークは不要。
+
+---
+
+## 10. 注意点（Caveats）
+
+- **フォントは CDN 配信**（自前ホストではない）。`tokens/fonts.css` が Space Grotesk + DM Sans + Noto Sans JP を Google Fonts から `@import`。mono はOSスタック。オフライン/自前ホストが必要なら `.woff2` を入れて `@import` をローカル `@font-face` に置換。
+- コードベース / Figma / ライブサイトは**提供されていない**。ブランドブリーフから起こしたもの。UI キットのサンプル内容（プロジェクト名・コピー・数値）は**説明用**であり、実素材に差し替えること。
+- Voice / Tone とアイコノグラフィは推定を含む。実物のサイトやリポジトリがあれば突き合わせ可能。

--- a/docs/design-gap.md
+++ b/docs/design-gap.md
@@ -1,0 +1,122 @@
+# Design Gap — 既存コード vs `DESIGN.md`
+
+`DESIGN.md`（SSoT）と現在の実装の乖離一覧。新規実装・リファクタ時はここを潰す方向で進める。
+**重要度**: 🔴 違反（DESIGN.md 明示禁止）/ 🟡 推奨外（指針外れ）/ 🟢 改善余地
+
+最終更新: 2026-06-08
+
+---
+
+## 1. グローバル / レイアウト
+
+| 場所 | 現状 | DESIGN.md ルール | 重要度 |
+|---|---|---|---|
+| `pages/layout.tsx:35` | `bg-gray-50` (cool gray) | 暖色ニュートラルのみ。`bg-surface-page` 相当 (`--paper #EFEDE3`) を使う | 🔴 |
+| `styles/globals.css` | Google Fonts 読み込みなし、html へのフォント指定なし | Space Grotesk / DM Sans / Noto Sans JP を CSS 経由でロードし、body は DM Sans | 🔴（→ tokens 導入で解決済） |
+| サーフェス・テキスト・ボーダー | hex / tailwind 標準色直書き | セマンティックエイリアス（`surface-*` / `ink-*` / `line-*`）経由 | 🔴 |
+
+---
+
+## 2. コンポーネント
+
+### `components/Button.tsx`
+```tsx
+bg-slate-500 hover:bg-slate-700 text-white py-2 px-4 rounded
+```
+- 🔴 cool gray（`slate-*`）を使用 → DESIGN.md は暖色ニュートラル限定。Primary は **インク (asphalt) on 紙 (paper)**。
+- 🔴 `rounded`（4px Tailwind 既定だが意図不明）→ `rounded-md`（= 4px トークン）を明示。
+- 🟡 variant / size プロップ未対応 → DESIGN.md §8 で `variant: primary/secondary`、`size: sm` を期待。
+- 🟡 hover が背景色トーン変更 → DESIGN.md §6 では「色 / ボーダーのシフト」+「プレスで 1px 下に translate」を期待。
+
+### `components/Header.tsx`
+- 🔴 `bg-slate-200 rounded-2xl` でアクティブナビを表現 → 16px radius は DESIGN.md（最大 6px）違反。色も cool gray。
+- 🟡 アクティブ表現は **2–3px のインク罫**（`--border-rule`）か Tabs underline が DESIGN.md の方向性。
+- 🟡 nav リンクの hover に hazard を出していない（DESIGN.md §2.4：nav の hover で hazard を使う）。
+
+### `components/Footer.tsx`
+- 🟢 機能的には問題なし。フォントロールが mono のマイクロラベルに置き換わるべき（コピーライト・リンクは mono + 大文字 + 0.16em tracking が DESIGN.md §1）。
+- 🟡 「&copy; kinjo shotaro 2024年」は固定年。動的化推奨。
+
+### `components/Tooltip.tsx`
+- 🔴 `bg-black text-white` → 黒は使わない。`asphalt` (`#302F2C`) + `paper` テキストへ。
+- 🔴 `rounded`（Tailwind 既定）→ `rounded-md` トークン明示。
+
+### `components/Heading.tsx`
+- 🟡 `font-bold` 固定 → DESIGN.md は Space Grotesk 500–700。h1 で `font-display font-semibold` 推奨。
+- 🟡 サイズマッピングが意図的タイポスケールでない（`text-2xl/xl/lg/md/sm/xs` の素直な対応） → `--text-h1/h2/h3` 合成ロールに合わせる。
+- 🟡 `my-3` 固定 → セクション縦リズム 64–128px 思想と合わない。マージン管理は親側に寄せる。
+
+### `components/Achievement.tsx`, `MembershipList.tsx`
+- 🟢 文言はシンプルで OK。
+- 🟡 リスト見出しが Heading コンポーネント経由 → タイポロール整備後に再評価。
+
+### `components/SNS.tsx`
+- 🟡 ICON_SIZE=60 とトークン外の数値。アイコンは Lucide の 24×24 グリッド + 1.5px stroke（DESIGN.md §7）を踏襲。デカすぎる気配。
+- 🟡 SVG を直書き（speakerdeck）→ Lucide にないなら別アイコンセットでも可（細・スクエア・モノラインを保つ）。
+
+---
+
+## 3. ページ
+
+### `pages/index.tsx`
+- 🔴 `text-gray-400` → cool gray。`text-ink-tertiary` (`--text-tertiary` = concrete) に。
+- 🟡 プロフィール画像 `rounded-lg` → 写真にも角丸最小（0–6px）。`rounded-md` か **角丸なし**（工業的）が望ましい。
+- 🟡 ヒーローコピーがブランドガイドの「一人称・単数の I」「事実淡々」と一致していない。`DESIGN.md §1` のヒーローコピー例に寄せる。
+
+### `pages/about.tsx`
+- 🟡 段落が長く Voice ガイド（短文・体言止め・形容詞 1 つ）と乖離。リライト対象。
+- 🟡 「Coming soon...」放置。プロダクトとして弱いので埋める or セクションごと隠す。
+
+### `pages/blog/index.tsx`
+- 🔴 `shadow-lg`（ソフト影）→ 影禁止。`lift` バリアントが必要なら `shadow-hard` のみ。
+- 🔴 `rounded overflow-hidden border-2` の組み合わせは grid カードとして DESIGN.md の `Card` 仕様に置き換え。
+- 🔴 `hover:border-gray-400` → cool gray。`hover:border-line-strong`（CONCRETE）に。
+- 🔴 `text-gray-400` → ink-tertiary。
+
+### `pages/blog/[id].tsx`
+- 🟡 「いいね！」ボタン文言に `！` 全角感嘆 + 絵文字感。DESIGN.md §1（誇張・感嘆禁止）。`Like` か `いいね` に。
+- 🟡 prose は `tailwind/typography` 標準のまま → DESIGN.md のフォント/字間/行間に合わせて `prose` カスタマイズが必要。
+
+### `pages/products/index.tsx`
+- 🔴 `shadow-lg` 影、`rounded` cool gray border-hover。blog 同様。
+- 🟡 `Card` コンポーネント未抽出。`DESIGN.md §8` の `Card` に置き換える。
+
+### `pages/products/[id].tsx`
+- 🔴 `text-blue-600 hover:text-blue-800` → リンク色は `--hazard #BB6A35` のみ。
+- 🟡 「作品 URL」見出しなど h3 を Heading コンポーネント経由にしていない。
+
+### `pages/work/index.tsx`
+- 🔴 `text-slate-400` → cool gray。`text-ink-tertiary`。
+- 🟡 期間表示は mono の小文字大文字（micro label）に。日付フォーマットも DESIGN.md の "FROM / TO" 表記に揃える余地。
+
+---
+
+## 4. トークン未使用箇所のサマリ
+
+| カテゴリ | 違反箇所数 | 対応 |
+|---|---|---|
+| cool gray (`slate-*`, `gray-*`) | 8 箇所 | `ink-*` / `line-*` / `surface-*` へ置換 |
+| `shadow-lg` | 2 箇所 | 削除、必要時のみ `shadow-hard` |
+| `rounded-2xl`, `rounded-lg` (UI コントロール) | 3 箇所 | `rounded-md`（4px） |
+| リンク色 (`text-blue-*`) | 1 箇所 | `<a>` 既定 hazard で OK（クラス削除） |
+| Emoji / 絵文字感のあるコピー | 1 箇所（"いいね！"） | 文言調整 |
+
+---
+
+## 5. 推奨される段階的移行プラン
+
+1. **基盤** — `styles/tokens.css` 導入 + Tailwind 接続 ✅ 済
+2. **共通コンポーネント刷新** — `Button` / `Card`（新規）/ `Tooltip` / `Header` / `Heading` を DESIGN.md §8 仕様で書き直し
+3. **ページ移行** — pages/* を新コンポーネントに差し替え、cool gray を一掃
+4. **prose スタイル** — blog 本文の typography をブランドフォントに揃える
+5. **コピー刷新** — index / about / blog タイトル等を Voice & Tone ガイドでリライト
+6. **アイコン整理** — Lucide 1.5px stroke / 24×24 を共通化、ICON_SIZE 廃止
+
+---
+
+## 6. 参照
+
+- SSoT: `../DESIGN.md`
+- トークン定義: `../styles/tokens.css`
+- Tailwind 接続: `../tailwind.config.ts`
+- プロジェクト規約: `../.claude/CLAUDE.md`

--- a/pages/layout.tsx
+++ b/pages/layout.tsx
@@ -32,7 +32,9 @@ export default function Layout({
     // }
   }, []);
   return (
-    <div className={`bg-gray-50 ${className}`}>
+    <div
+      className={`min-h-screen bg-surface-page text-ink-primary ${className ?? ""}`}
+    >
       <div className="flex justify-center">
         <Header />
       </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,50 @@
+@import "./tokens.css";
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    background-color: var(--surface-page);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    font-size: var(--size-md);
+    line-height: var(--leading-normal);
+  }
+
+  body {
+    background-color: var(--surface-page);
+    color: var(--text-primary);
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: var(--font-display);
+    letter-spacing: var(--tracking-tight);
+    line-height: var(--leading-snug);
+    color: var(--text-primary);
+  }
+
+  a {
+    color: var(--link);
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+    transition: color var(--duration-fast) var(--ease-standard);
+  }
+
+  a:hover {
+    color: var(--accent-hover);
+  }
+
+  ::selection {
+    background-color: var(--asphalt);
+    color: var(--paper);
+  }
+}
 
 @keyframes fadeIn {
   from {
@@ -12,5 +56,5 @@
 }
 
 .page-enter {
-  animation: fadeIn 0.8s ease-out forwards;
+  animation: fadeIn var(--duration-slow) var(--ease-standard) forwards;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,182 @@
+/*
+ * Aphro Design System — Tokens
+ * SSoT: ../DESIGN.md
+ * 直接 hex を書かず、ここで定義されたトークン経由で参照する。
+ */
+
+:root {
+  /* ---- 2.2 Neutral ramp (warm, low-chroma 16-step) ---- */
+  --neutral-950: #1b1a18;
+  --neutral-900: #232220;
+  --neutral-850: #2a2926;
+  --neutral-800: #302f2c; /* = ASPHALT */
+  --neutral-700: #494742;
+  --neutral-600: #625f59;
+  --neutral-500: #777370;
+  --neutral-450: #8a8680; /* = CONCRETE */
+  --neutral-400: #9d9a94;
+  --neutral-300: #b6b3ac;
+  --neutral-250: #c5c2bb;
+  --neutral-200: #d4d1c9;
+  --neutral-150: #e1ddd2;
+  --neutral-100: #efede3; /* = PAPER */
+  --neutral-50: #f5f3eb;
+  --neutral-0: #faf8f0;
+
+  /* ---- 2.1 Material anchors ---- */
+  --asphalt: var(--neutral-800);
+  --concrete: var(--neutral-450);
+  --paper: var(--neutral-100);
+
+  /* ---- 2.3 Signal tones ---- */
+  --signal-positive: #5c6e54;
+  --signal-caution: #9c7b3f;
+  --signal-critical: #92503f;
+  --signal-info: #4f6470;
+
+  /* ---- 2.4 Hazard accent (links only) ---- */
+  --hazard: #bb6a35;
+  --hazard-deep: #a85a2b;
+  --accent: var(--hazard);
+  --accent-hover: var(--hazard-deep);
+  --link: var(--hazard);
+
+  /* ---- 2.5 Semantic aliases — Paper context (default) ---- */
+  --surface-page: var(--paper);
+  --surface-raised: var(--neutral-50);
+  --surface-sunken: var(--neutral-150);
+  --surface-card: var(--neutral-0);
+  --surface-inverse: var(--asphalt);
+
+  --text-primary: var(--asphalt);
+  --text-secondary: var(--neutral-600);
+  --text-tertiary: var(--concrete);
+  --text-disabled: var(--neutral-300);
+  --text-on-inverse: var(--paper);
+
+  --border-strong: var(--concrete);
+  --border-default: var(--neutral-300);
+  --border-subtle: var(--neutral-200);
+  --divider: var(--neutral-200);
+  --border-thick: 2px;
+  --border-rule: 3px;
+
+  --action-primary-bg: var(--asphalt);
+  --action-primary-fg: var(--paper);
+  --action-primary-bg-hover: var(--neutral-900);
+  --action-secondary-bg: transparent;
+  --action-secondary-fg: var(--asphalt);
+  --action-secondary-border: var(--asphalt);
+  --action-ghost-bg: transparent;
+  --action-ghost-fg: var(--asphalt);
+  --focus-ring: var(--hazard);
+
+  /* ---- 3.1 Type scale (1.250 major-third) ---- */
+  --size-3xs: 11px;
+  --size-2xs: 12px;
+  --size-xs: 13px;
+  --size-sm: 14px;
+  --size-md: 16px;
+  --size-lg: 18px;
+  --size-xl: 22px;
+  --size-2xl: 28px;
+  --size-3xl: 36px;
+  --size-4xl: 48px;
+  --size-5xl: 64px;
+  --size-6xl: 88px;
+
+  /* ---- 3.2 Leading & tracking ---- */
+  --leading-tight: 1.05;
+  --leading-snug: 1.18;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.7;
+  --tracking-tight: -0.02em;
+  --tracking-snug: -0.01em;
+  --tracking-wide: 0.08em;
+  --tracking-wider: 0.16em;
+
+  /* ---- 3 Fonts ---- */
+  --font-display: "Space Grotesk", "Noto Sans JP", system-ui, sans-serif;
+  --font-body: "DM Sans", "Noto Sans JP", system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --font-jp: "Noto Sans JP", system-ui, sans-serif;
+
+  /* ---- 4 Spacing scale (4px base / 8px rhythm) ---- */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --space-9: 96px;
+  --space-10: 128px;
+  --space-11: 192px;
+
+  /* ---- 4 Containers ---- */
+  --container-prose: 68ch;
+  --container-narrow: 720px;
+  --container-content: 1080px;
+  --container-wide: 1320px;
+  --gutter: var(--space-5);
+
+  /* ---- 5 Radius (max 6px, pill only for tags/avatars) ---- */
+  --radius-xs: 2px;
+  --radius-sm: 3px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+  --radius-pill: 999px;
+
+  /* ---- 5 Depth — only flat hard offset allowed ---- */
+  --shadow-hard: 4px 4px 0 0 var(--asphalt);
+
+  /* ---- 6 Motion ---- */
+  --duration-fast: 120ms;
+  --duration-normal: 200ms;
+  --duration-slow: 320ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0.2, 1);
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+}
+
+/* ---- 2.6 Asphalt (dark) surface context ---- */
+[data-theme="asphalt"] {
+  --surface-page: var(--asphalt);
+  --surface-raised: var(--neutral-850);
+  --surface-sunken: var(--neutral-900);
+  --surface-card: var(--neutral-850);
+  --surface-inverse: var(--paper);
+
+  --text-primary: var(--paper);
+  --text-secondary: var(--neutral-300);
+  --text-tertiary: var(--concrete);
+  --text-disabled: var(--neutral-600);
+  --text-on-inverse: var(--asphalt);
+
+  --border-strong: var(--neutral-500);
+  --border-default: var(--neutral-700);
+  --border-subtle: var(--neutral-800);
+  --divider: var(--neutral-800);
+
+  --action-primary-bg: var(--paper);
+  --action-primary-fg: var(--asphalt);
+  --action-primary-bg-hover: var(--neutral-50);
+  --action-secondary-fg: var(--paper);
+  --action-secondary-border: var(--paper);
+  --action-ghost-fg: var(--paper);
+
+  /* DESIGN.md §2.4: Asphalt context lifts hazard for legibility */
+  --hazard: #cf8348;
+  --hazard-deep: #dd9358;
+  --accent: var(--hazard);
+  --accent-hover: var(--hazard-deep);
+  --link: var(--hazard);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --duration-fast: 0ms;
+    --duration-normal: 0ms;
+    --duration-slow: 0ms;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,9 @@
 import type { Config } from "tailwindcss";
 
+/**
+ * Tailwind theme is wired to CSS variables defined in styles/tokens.css.
+ * SSoT for design decisions: DESIGN.md
+ */
 const config: Config = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
@@ -8,15 +12,153 @@ const config: Config = {
   ],
   theme: {
     extend: {
-      backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+      colors: {
+        // Material anchors
+        asphalt: "var(--asphalt)",
+        concrete: "var(--concrete)",
+        paper: "var(--paper)",
+
+        // Neutral ramp
+        neutral: {
+          0: "var(--neutral-0)",
+          50: "var(--neutral-50)",
+          100: "var(--neutral-100)",
+          150: "var(--neutral-150)",
+          200: "var(--neutral-200)",
+          250: "var(--neutral-250)",
+          300: "var(--neutral-300)",
+          400: "var(--neutral-400)",
+          450: "var(--neutral-450)",
+          500: "var(--neutral-500)",
+          600: "var(--neutral-600)",
+          700: "var(--neutral-700)",
+          800: "var(--neutral-800)",
+          850: "var(--neutral-850)",
+          900: "var(--neutral-900)",
+          950: "var(--neutral-950)",
+        },
+
+        // Signals
+        signal: {
+          positive: "var(--signal-positive)",
+          caution: "var(--signal-caution)",
+          critical: "var(--signal-critical)",
+          info: "var(--signal-info)",
+        },
+
+        // Accent
+        hazard: {
+          DEFAULT: "var(--hazard)",
+          deep: "var(--hazard-deep)",
+        },
+        accent: {
+          DEFAULT: "var(--accent)",
+          hover: "var(--accent-hover)",
+        },
+
+        // Semantic aliases
+        surface: {
+          page: "var(--surface-page)",
+          raised: "var(--surface-raised)",
+          sunken: "var(--surface-sunken)",
+          card: "var(--surface-card)",
+          inverse: "var(--surface-inverse)",
+        },
+        ink: {
+          primary: "var(--text-primary)",
+          secondary: "var(--text-secondary)",
+          tertiary: "var(--text-tertiary)",
+          disabled: "var(--text-disabled)",
+          "on-inverse": "var(--text-on-inverse)",
+        },
+        line: {
+          strong: "var(--border-strong)",
+          DEFAULT: "var(--border-default)",
+          subtle: "var(--border-subtle)",
+          divider: "var(--divider)",
+        },
+      },
+      fontFamily: {
+        display: "var(--font-display)",
+        body: "var(--font-body)",
+        mono: "var(--font-mono)",
+        jp: "var(--font-jp)",
+      },
+      fontSize: {
+        "3xs": "var(--size-3xs)",
+        "2xs": "var(--size-2xs)",
+        xs: "var(--size-xs)",
+        sm: "var(--size-sm)",
+        md: "var(--size-md)",
+        base: "var(--size-md)",
+        lg: "var(--size-lg)",
+        xl: "var(--size-xl)",
+        "2xl": "var(--size-2xl)",
+        "3xl": "var(--size-3xl)",
+        "4xl": "var(--size-4xl)",
+        "5xl": "var(--size-5xl)",
+        "6xl": "var(--size-6xl)",
+      },
+      lineHeight: {
+        tight: "var(--leading-tight)",
+        snug: "var(--leading-snug)",
+        normal: "var(--leading-normal)",
+        relaxed: "var(--leading-relaxed)",
+      },
+      letterSpacing: {
+        tight: "var(--tracking-tight)",
+        snug: "var(--tracking-snug)",
+        wide: "var(--tracking-wide)",
+        wider: "var(--tracking-wider)",
+      },
+      spacing: {
+        1: "var(--space-1)",
+        2: "var(--space-2)",
+        3: "var(--space-3)",
+        4: "var(--space-4)",
+        5: "var(--space-5)",
+        6: "var(--space-6)",
+        7: "var(--space-7)",
+        8: "var(--space-8)",
+        9: "var(--space-9)",
+        10: "var(--space-10)",
+        11: "var(--space-11)",
+      },
+      maxWidth: {
+        prose: "var(--container-prose)",
+        narrow: "var(--container-narrow)",
+        content: "var(--container-content)",
+        wide: "var(--container-wide)",
+      },
+      borderRadius: {
+        none: "0",
+        xs: "var(--radius-xs)",
+        sm: "var(--radius-sm)",
+        md: "var(--radius-md)",
+        DEFAULT: "var(--radius-md)",
+        lg: "var(--radius-lg)",
+        pill: "var(--radius-pill)",
+      },
+      borderWidth: {
+        DEFAULT: "1px",
+        thick: "var(--border-thick)",
+        rule: "var(--border-rule)",
+      },
+      boxShadow: {
+        none: "none",
+        hard: "var(--shadow-hard)",
+      },
+      transitionDuration: {
+        fast: "var(--duration-fast)",
+        normal: "var(--duration-normal)",
+        slow: "var(--duration-slow)",
+      },
+      transitionTimingFunction: {
+        standard: "var(--ease-standard)",
+        out: "var(--ease-out)",
       },
     },
   },
-  plugins: [
-    require("@tailwindcss/typography"),
-  ],
+  plugins: [require("@tailwindcss/typography")],
 };
 export default config;


### PR DESCRIPTION
## 概要

「アフロ Design System」の基盤を一括整備。今後のデザイン関連の変更は本 PR で導入したルールとトークンに従う。

## 変更点

### 1. `DESIGN.md`（SSoT）
- ブランド・ボイス・カラー・タイポ・スペーシング・ボーダー・モーション・アイコノグラフィ・コンポーネント仕様を網羅。
- 色/タイポ/コピーの判断はここを参照。

### 2. `.claude/CLAUDE.md`
- UI / トークン / コピー変更時に `DESIGN.md` を必ず参照する規約を明文化。
- 主要禁止事項（ソフト影、グラデ、cool gray、emoji、非 hazard リンク色 等）を抜粋。

### 3. `styles/tokens.css` + Tailwind 接続
- DESIGN.md の全トークン（neutral ramp 16 段、signal、hazard、surface/text/border/action セマンティック、type scale、spacing、radius、motion）を CSS variables で実装。
- Paper（明） / Asphalt（暗）の 2 文脈を `[data-theme=\"asphalt\"]` で切り替え。
- `tailwind.config.ts` の theme.extend からトークンを参照（`bg-paper`, `text-ink-primary`, `border-line-strong`, `rounded-md`, `shadow-hard` 等）。
- `prefers-reduced-motion` で duration を 0 に。
- Google Fonts（Space Grotesk / DM Sans / Noto Sans JP）を `styles/globals.css` から読み込み。

### 4. `docs/design-gap.md`
- 既存コード（components / pages / styles）と DESIGN.md の乖離を一覧化。
- 重要度（🔴/🟡/🟢）と段階的移行プランを記載。次のリファクタの作業計画になる。

## 確認

- [x] `pnpm build` 通過
- [x] 既存ページ（home / blog / products / work）は表示崩れなし（旧 utility クラスはそのまま動作）

## TODO（別 PR）

`docs/design-gap.md` の段階的移行プランに従う:
1. 共通コンポーネント刷新（Button / Card / Tooltip / Header / Heading）
2. ページ移行（pages/* を新コンポーネント + 新トークンに）
3. blog 本文の prose スタイル整備
4. コピー刷新（Voice & Tone ガイド適用）
5. アイコン整理（Lucide 1.5px / 24x24）