### PR TITLE
feat: SNSを黒で統一しスマホでgrid表示

### DIFF
--- a/components/SNS.tsx
+++ b/components/SNS.tsx
@@ -1,25 +1,27 @@
 import Image from "next/image";
 import { Github } from "lucide-react";
+
 export default function SNS() {
-  const ICON_SIZE = 60;
+  const ICON_SIZE = 48;
   // SNS はブランドアイコン。Lucide (Github) は currentColor を継承するため
   // グローバルの hazard リンク色に染まらないよう ink-primary を明示。
   const linkClass =
-    "inline-flex items-center text-ink-primary hover:text-ink-primary no-underline";
+    "inline-flex items-center justify-center text-ink-primary hover:text-ink-primary no-underline";
   return (
     <div className="mt-10">
       <h3 className="font-bold text-2xl">SNS</h3>
-      <ul className="flex break-words gap-4 overflow-x-auto items-center">
+      <ul className="mt-4 grid grid-cols-4 gap-4 items-center sm:flex sm:flex-wrap sm:gap-6">
         <li>
           <a
             href="https://twitter.com/kinjyo1130"
             target="_blank"
             rel="noopener noreferrer"
             className={linkClass}
+            aria-label="X"
           >
             <Image
               src="/sns/x.svg"
-              alt="X"
+              alt=""
               width={ICON_SIZE}
               height={ICON_SIZE}
             />
@@ -31,6 +33,7 @@ export default function SNS() {
             target="_blank"
             rel="noopener noreferrer"
             className={linkClass}
+            aria-label="GitHub"
           >
             <Github size={ICON_SIZE} strokeWidth={1.5} />
           </a>
@@ -41,10 +44,11 @@ export default function SNS() {
             target="_blank"
             rel="noopener noreferrer"
             className={linkClass}
+            aria-label="Instagram"
           >
             <Image
               src="/sns/instagram.svg"
-              alt="Instagram"
+              alt=""
               width={ICON_SIZE}
               height={ICON_SIZE}
             />
@@ -56,13 +60,13 @@ export default function SNS() {
             target="_blank"
             rel="noopener noreferrer"
             className={linkClass}
+            aria-label="Qiita"
           >
             <Image
               src="/sns/qiita.png"
-              alt="Qiita"
+              alt=""
               width={ICON_SIZE}
               height={ICON_SIZE}
-              className="min-w-16"
             />
           </a>
         </li>
@@ -72,13 +76,13 @@ export default function SNS() {
             target="_blank"
             rel="noopener noreferrer"
             className={linkClass}
+            aria-label="Zenn"
           >
             <Image
               src="/sns/zenn.svg"
-              alt="Zenn"
+              alt=""
               width={ICON_SIZE}
               height={ICON_SIZE}
-              className="min-w-16"
             />
           </a>
         </li>
@@ -96,6 +100,7 @@ export default function SNS() {
               height={ICON_SIZE}
               viewBox="0 0 32 32"
               aria-hidden="true"
+              fill="currentColor"
             >
               <path d="M 8 8 C 5.243 8 3 10.243 3 13 C 3 15.757 5.243 18 8 18 L 14 18 C 14.551 18 15 18.448 15 19 C 15 19.552 14.551 20 14 20 L 5 20 C 3.896 20 3 20.896 3 22 C 3 23.104 3.896 24 5 24 L 14 24 C 16.757 24 19 21.757 19 19 C 19 16.243 16.757 14 14 14 L 8 14 C 7.449 14 7 13.552 7 13 C 7 12.448 7.449 12 8 12 L 15 12 C 16.104 12 17 11.104 17 10 C 17 8.896 16.104 8 15 8 L 8 8 z M 18.445312 8 C 18.789313 8.59 19 9.268 19 10 C 19 10.734 18.783453 11.409 18.439453 12 L 24 12 C 24.552 12 25 12.448 25 13 L 25 19 C 25 19.552 24.552 20 24 20 L 20.919922 20 C 20.695922 21.556 19.963672 22.949 18.888672 24 L 25 24 C 27.209 24 29 22.209 29 20 L 29 12 C 29 9.791 27.209 8 25 8 L 18.445312 8 z" />
             </svg>
@@ -107,13 +112,13 @@ export default function SNS() {
             target="_blank"
             rel="noopener noreferrer"
             className={linkClass}
+            aria-label="Scrapbox"
           >
             <Image
               src="/sns/scrapbox.png"
-              alt="Scrapbox"
+              alt=""
               width={ICON_SIZE}
               height={ICON_SIZE}
-              className="min-w-16"
             />
           </a>
         </li>


### PR DESCRIPTION
## Summary

SNS アイコンの色を黒系に統一し、スマートフォンで横スクロールではなくグリッドで表示されるよう修正。

## Changes

- `public/sns/instagram.svg` — Gradient Glyph (10.4 MB) を **Black Glyph (1.8 KB)** に置換。ファイルサイズ約 6000 倍削減
- `components/SNS.tsx`
  - `<ul>` を `grid grid-cols-4 gap-4 items-center sm:flex sm:flex-wrap sm:gap-6` に変更
    - スマホ: 4 列グリッドで折り返し (7 アイコン → 4+3)
    - sm 以上 (≥640px): flex で横並び、必要に応じて折り返し
  - 横スクロール (`overflow-x-auto`) を廃止
  - ICON_SIZE を 60 → **48** にダウン（スマホで詰まりすぎない）
  - 全 `<a>` に `aria-label` を付与、`<Image>` の `alt` は空文字（装飾用）に
  - Speaker Deck SVG に `fill="currentColor"` を明示
  - `min-w-16` を削除（grid/flex で幅制御）

## Test Plan

- [x] `pnpm build` 通過
- [ ] スマホ幅 (375px) で 4 列グリッドになるか確認
- [ ] デスクトップで flex 横並びになるか確認
- [ ] Instagram アイコンが黒一色に変わっているか確認
- [ ] X / GitHub / Instagram の 3 つが視覚的に同じ黒系で統一されているか確認

## Screenshots

差し替え後のホーム下部 (SNS セクション) を貼る想定。

## Additional Notes

- Qiita / Zenn / Scrapbox は元々色付きの画像アセットで黒版が無いため、現状のまま据え置き。完全な黒統一が必要なら、各サービスの黒版アイコン（SVG）を別途入手して `public/sns/` に追加して差し替える。
- このブランチでは hero 関連の作業中ファイル (`pages/index.tsx`, `styles/globals.css`, `styles/tokens.css`, `public/textures/`) はコミットしていない。それらは別 PR で進める。