### PR TITLE
feat: 画像クロップツール (/tools/crop) を追加

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -48,6 +48,12 @@ export const Header: React.FC = () => {
 			>
 				<p>work</p>
 			</Link>
+			<Link
+				href="/tools/crop"
+				className={`underline hover:no-underline ${isActive("/tools")}`}
+			>
+				<p>tools</p>
+			</Link>
 			{/* <Link
 				href="/about"
 				className={`underline hover:no-underline ${isActive("/about")}`}

--- a/libs/crop.ts
+++ b/libs/crop.ts
@@ -1,0 +1,112 @@
+export type CropArea = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type OutputFormat = "webp" | "png" | "jpg";
+
+const MIME: Record<OutputFormat, string> = {
+  webp: "image/webp",
+  png: "image/png",
+  jpg: "image/jpeg",
+};
+
+async function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = (e) => reject(e);
+    img.src = src;
+  });
+}
+
+type CropOptions = {
+  imageSrc: string;
+  crop: CropArea;
+  format: OutputFormat;
+  quality?: number;
+  maxWidth?: number | null;
+  fixedSize?: { width: number; height: number } | null;
+};
+
+export async function getCroppedBlob({
+  imageSrc,
+  crop,
+  format,
+  quality = 0.92,
+  maxWidth = null,
+  fixedSize = null,
+}: CropOptions): Promise<Blob> {
+  const img = await loadImage(imageSrc);
+
+  let outW = crop.width;
+  let outH = crop.height;
+
+  if (fixedSize) {
+    outW = fixedSize.width;
+    outH = fixedSize.height;
+  } else if (maxWidth && crop.width > maxWidth) {
+    const scale = maxWidth / crop.width;
+    outW = Math.round(crop.width * scale);
+    outH = Math.round(crop.height * scale);
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = outW;
+  canvas.height = outH;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D context unavailable");
+
+  if (format === "jpg") {
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, outW, outH);
+  }
+
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
+
+  ctx.drawImage(
+    img,
+    crop.x,
+    crop.y,
+    crop.width,
+    crop.height,
+    0,
+    0,
+    outW,
+    outH,
+  );
+
+  const mime = MIME[format];
+  const blob: Blob = await new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) => {
+        if (b) resolve(b);
+        else reject(new Error("toBlob returned null"));
+      },
+      mime,
+      format === "png" ? undefined : quality,
+    );
+  });
+
+  return blob;
+}
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "14.2.35",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-easy-crop": "^5.5.7",
     "rehype-highlight": "^7.0.2",
     "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",

--- a/pages/tools/crop.tsx
+++ b/pages/tools/crop.tsx
@@ -1,0 +1,296 @@
+import { SeoHead } from "@/components/SeoHead";
+import {
+  downloadBlob,
+  formatBytes,
+  getCroppedBlob,
+  type CropArea,
+  type OutputFormat,
+} from "@/libs/crop";
+import { useCallback, useMemo, useRef, useState } from "react";
+import Cropper from "react-easy-crop";
+import Layout from "../layout";
+
+type Preset = {
+  id: string;
+  label: string;
+  ratio: number | null;
+  fixedSize?: { width: number; height: number };
+};
+
+const PRESETS: Preset[] = [
+  { id: "ogp", label: "OGP 1200×630", ratio: 1200 / 630, fixedSize: { width: 1200, height: 630 } },
+  { id: "16x9", label: "16:9", ratio: 16 / 9 },
+  { id: "1x1", label: "1:1", ratio: 1 },
+  { id: "free", label: "Free", ratio: null },
+];
+
+const FORMATS: { id: OutputFormat; label: string }[] = [
+  { id: "webp", label: "WEBP" },
+  { id: "png", label: "PNG" },
+  { id: "jpg", label: "JPG" },
+];
+
+export default function CropPage() {
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [originalName, setOriginalName] = useState<string>("image");
+  const [originalSize, setOriginalSize] = useState<number>(0);
+  const [presetId, setPresetId] = useState<string>("ogp");
+  const [format, setFormat] = useState<OutputFormat>("webp");
+  const [quality, setQuality] = useState<number>(0.92);
+  const [maxWidth, setMaxWidth] = useState<number | "">("");
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedArea, setCroppedArea] = useState<CropArea | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const preset = useMemo(
+    () => PRESETS.find((p) => p.id === presetId) ?? PRESETS[0],
+    [presetId],
+  );
+
+  const onCropComplete = useCallback((_: CropArea, area: CropArea) => {
+    setCroppedArea(area);
+  }, []);
+
+  const handleFile = (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      setError("画像ファイルを選択してください");
+      return;
+    }
+    setError(null);
+    setOriginalName(file.name.replace(/\.[^.]+$/, ""));
+    setOriginalSize(file.size);
+    const reader = new FileReader();
+    reader.onload = () => {
+      setImageSrc(reader.result as string);
+      setCrop({ x: 0, y: 0 });
+      setZoom(1);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const onPickFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  const onDownload = async () => {
+    if (!imageSrc || !croppedArea) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const blob = await getCroppedBlob({
+        imageSrc,
+        crop: croppedArea,
+        format,
+        quality,
+        maxWidth: typeof maxWidth === "number" ? maxWidth : null,
+        fixedSize: preset.fixedSize ?? null,
+      });
+      const ext = format === "jpg" ? "jpg" : format;
+      downloadBlob(blob, `${originalName}-crop.${ext}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "書き出しに失敗しました");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onReset = () => {
+    setImageSrc(null);
+    setOriginalName("image");
+    setOriginalSize(0);
+    setCroppedArea(null);
+    setCrop({ x: 0, y: 0 });
+    setZoom(1);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const labelClass = "block text-2xs font-mono uppercase tracking-wider text-ink-secondary mb-2";
+  const chipBase =
+    "px-3 py-2 text-xs font-mono uppercase tracking-wider border border-line transition-colors duration-fast";
+  const chipActive = "bg-asphalt text-paper border-asphalt";
+  const chipInactive = "bg-transparent text-ink-primary hover:border-line-strong";
+
+  return (
+    <>
+      <SeoHead
+        title="Image Crop"
+        titleTemplate="Image Crop"
+        description="サムネイル・OGP・SNSアイコン用の画像を素早くトリミング"
+        imgUrl="/favicon.ico"
+      />
+      <Layout title="Image crop" tooltipText="ローカル完結のクライアントサイド画像クロップツール">
+        <div className="mb-6">
+          <p className="text-sm text-ink-secondary">
+            画像はあなたのブラウザ内だけで処理されます。サーバーには送信されません。
+          </p>
+        </div>
+
+        {!imageSrc ? (
+          <div
+            onDrop={onDrop}
+            onDragOver={(e) => e.preventDefault()}
+            className="border border-line-strong p-8 text-center"
+          >
+            <p className="font-mono text-xs uppercase tracking-wider text-ink-secondary mb-4">
+              Drop image here
+            </p>
+            <p className="text-sm text-ink-secondary mb-4">— or —</p>
+            <label className="inline-block">
+              <span className="inline-block bg-asphalt text-paper px-5 py-3 text-sm font-medium cursor-pointer hover:bg-neutral-900 transition-colors duration-fast">
+                Choose file
+              </span>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={onPickFile}
+              />
+            </label>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+            <div className="lg:col-span-8">
+              <div
+                className="relative w-full bg-asphalt"
+                style={{ aspectRatio: preset.ratio ?? 16 / 9, minHeight: 320 }}
+              >
+                <Cropper
+                  image={imageSrc}
+                  crop={crop}
+                  zoom={zoom}
+                  aspect={preset.ratio ?? undefined}
+                  onCropChange={setCrop}
+                  onZoomChange={setZoom}
+                  onCropComplete={onCropComplete}
+                  showGrid
+                  restrictPosition={false}
+                />
+              </div>
+              <div className="mt-4">
+                <span className={labelClass}>Zoom</span>
+                <input
+                  type="range"
+                  min={1}
+                  max={5}
+                  step={0.01}
+                  value={zoom}
+                  onChange={(e) => setZoom(Number(e.target.value))}
+                  className="w-full"
+                />
+              </div>
+            </div>
+
+            <div className="lg:col-span-4 space-y-6">
+              <section>
+                <span className={labelClass}>Preset</span>
+                <div className="flex flex-wrap gap-2">
+                  {PRESETS.map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      className={`${chipBase} ${presetId === p.id ? chipActive : chipInactive}`}
+                      onClick={() => setPresetId(p.id)}
+                    >
+                      {p.label}
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              <section>
+                <span className={labelClass}>Format</span>
+                <div className="flex gap-2">
+                  {FORMATS.map((f) => (
+                    <button
+                      key={f.id}
+                      type="button"
+                      className={`${chipBase} ${format === f.id ? chipActive : chipInactive}`}
+                      onClick={() => setFormat(f.id)}
+                    >
+                      {f.label}
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              {format !== "png" && (
+                <section>
+                  <span className={labelClass}>
+                    Quality{" "}
+                    <span className="text-ink-tertiary">{Math.round(quality * 100)}%</span>
+                  </span>
+                  <input
+                    type="range"
+                    min={0.5}
+                    max={1}
+                    step={0.01}
+                    value={quality}
+                    onChange={(e) => setQuality(Number(e.target.value))}
+                    className="w-full"
+                  />
+                </section>
+              )}
+
+              {!preset.fixedSize && (
+                <section>
+                  <span className={labelClass}>Max width (px, optional)</span>
+                  <input
+                    type="number"
+                    min={100}
+                    step={1}
+                    placeholder="未指定なら原寸"
+                    value={maxWidth}
+                    onChange={(e) =>
+                      setMaxWidth(e.target.value === "" ? "" : Number(e.target.value))
+                    }
+                    className="w-full border border-line bg-surface-card px-3 py-2 text-sm focus:outline-none focus:border-line-strong"
+                  />
+                </section>
+              )}
+
+              <section>
+                <span className={labelClass}>Source</span>
+                <p className="text-xs text-ink-secondary font-mono">
+                  {originalName} · {formatBytes(originalSize)}
+                </p>
+              </section>
+
+              {error && (
+                <p className="text-xs text-signal-critical font-mono">{error}</p>
+              )}
+
+              <div className="flex flex-col gap-2 pt-2">
+                <button
+                  type="button"
+                  onClick={onDownload}
+                  disabled={busy || !croppedArea}
+                  className="bg-asphalt text-paper px-5 py-3 text-sm font-medium hover:bg-neutral-900 transition-colors duration-fast disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {busy ? "Working…" : "Download"}
+                </button>
+                <button
+                  type="button"
+                  onClick={onReset}
+                  className="border border-asphalt text-ink-primary px-5 py-3 text-sm font-medium hover:bg-asphalt hover:text-paper transition-colors duration-fast"
+                >
+                  Reset
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </Layout>
+    </>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-easy-crop:
+        specifier: ^5.5.7
+        version: 5.5.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rehype-highlight:
         specifier: ^7.0.2
         version: 7.0.2
@@ -943,6 +946,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -1064,6 +1070,12 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-easy-crop@5.5.7:
+    resolution: {integrity: sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -2273,6 +2285,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  normalize-wheel@1.0.1: {}
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -2375,6 +2389,13 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-easy-crop@5.5.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
 
   react@18.3.1:
     dependencies:


### PR DESCRIPTION
## Summary

サムネイル・OGP・SNSアイコン等の画像を素早くトリミングするツールを `/tools/crop` に追加。完全にクライアントサイドで処理（画像はサーバーに送信されない）。

## Changes

- `react-easy-crop` を依存追加
- `libs/crop.ts` — Canvas でクロップ → Blob 生成、フォーマット変換、ダウンロードヘルパー
- `pages/tools/crop.tsx` — クロップツールページ
  - ドラッグ&ドロップ / ファイル選択でアップロード
  - プリセット: **OGP 1200×630** (固定サイズ出力) / **16:9** / **1:1** / **Free**
  - 出力フォーマット: **WEBP** (推奨) / **PNG** / **JPG**
  - WEBP/JPG はクオリティスライダー (50%-100%)
  - Free・16:9・1:1 は最大幅 (px) の任意指定でリサイズ
  - ズームスライダー (1×-5×)
  - ダウンロードボタン → `{元のファイル名}-crop.{ext}` で保存
- `components/Header.tsx` — グローバルナビに `tools` リンクを追加

## Test Plan

- [x] `pnpm build` 通過 (`/tools/crop` は static page、12.3 KB)
- [ ] ローカルで画像をアップロード → 各プリセットでクロップ → 各フォーマットでダウンロードできることを確認
- [ ] OGP プリセットは 1200×630 px 固定で書き出されることを確認
- [ ] PNG はクオリティスライダーが非表示になることを確認

## Screenshots

差し替え後の `/tools/crop` 画面を貼る想定。

## Additional Notes

- 完全にクライアント処理 (Canvas) なので、アップロードした画像はブラウザの外に出ない
- 公開ツールだが SEO 的な訪問流入は想定しておらず、自分が使うのが主目的
- 追加プリセットや出力上限の細かい制御は後追いで拡張しやすい構造 (PRESETS 配列を増やすだけ)
- DESIGN.md のトークン (`bg-asphalt`, `text-paper`, `border-line-strong`, font-mono のマイクロラベル) で UI を構築