### PR TITLE
fix: product詳細ページの画像を最大70vhに制限

### DIFF
--- a/pages/products/[slug].tsx
+++ b/pages/products/[slug].tsx
@@ -21,10 +21,11 @@ export default function ProductDetail({ product }: { product: Product }) {
 				</div>
 				<Image
 					src={product.image.url}
-					alt="product image"
+					alt={product.title}
 					width={product.image.width}
 					height={product.image.height}
-					className="w-full"
+					sizes="(min-width: 768px) 640px, 100vw"
+					className="mx-auto h-auto w-auto max-h-[70vh] max-w-full object-contain"
 				/>
 				{product.url && (
 					<div className="mt-6">


### PR DESCRIPTION
## Summary

product 詳細ページの hero 画像が `w-full` で親幅まで広がり、縦長スクショ（mapmemo: 1170×2532）だと画面いっぱいを超えて巨大表示されていた問題を修正。

## Changes

- `pages/products/[slug].tsx` の `<Image>` クラスを差し替え
  - `w-full` → `mx-auto h-auto w-auto max-h-[70vh] max-w-full object-contain`
  - `sizes="(min-width: 768px) 640px, 100vw"` を追加（next/image の最適配信ヒント）
  - 縦長画像は viewport 高さの 70% に収まり中央表示
  - 横長画像は最大 100% 幅で表示
- alt を固定文字列から `product.title` に変更

## Test Plan

- [x] `pnpm build` 通過
- [ ] `/products/mapmemo`（縦長スクショ）が画面内に収まることを確認
- [ ] `/products/rafutabi`（横長 3014×1640）が崩れないことを確認
- [ ] `/products/favarite-text-site` も確認

## Additional Notes

`70vh` は妥当な暗黙の上限値として採用。必要なら DESIGN.md にトークン化（例: `--media-max-h: 70vh`）して `tailwind.config.ts` から参照する余地あり。