### PR TITLE
fix: remove home background rules

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,7 +47,7 @@ export default function Home({
 				description="A frontend engineer's portfolio."
 				imgUrl="/favicon.ico"
 			/>
-			<div className="min-h-screen text-ink-primary">
+			<div className="home-plain-paper min-h-screen text-ink-primary">
 				<div className="flex justify-center">
 					<Header />
 				</div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -147,6 +147,15 @@
 .page-enter > *:nth-child(6) { animation-delay: 400ms; }
 .page-enter > *:nth-child(n + 7) { animation-delay: 480ms; }
 
+.home-plain-paper {
+  background-color: var(--surface-page);
+  background-image: url("/textures/paper-grain.svg");
+  background-size: 320px 320px;
+  background-attachment: scroll;
+  background-position: top left;
+  background-repeat: repeat;
+}
+
 /* Decorative rule that animates in */
 .rule-line {
   display: block;


### PR DESCRIPTION
## What changed

- Added a home-page-only wrapper class to override the global ruled-paper background.
- Kept the paper grain texture while removing the horizontal background rules on the top page.

## Why

The top page should no longer show the ruled background lines behind its content.

## Impact

Only the top page background is affected. Other pages keep the existing global ruled-paper background.

## Validation

- `pnpm build`