### PR TITLE
docs: DESIGN.md を v2 スペックに刷新

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,16 +4,18 @@
 
 UI / トークン / コピー / アイコノグラフィに関する変更は、必ずリポジトリ root の `DESIGN.md` を参照すること。`DESIGN.md` がアフロ Design System の Single Source of Truth。
 
-### 必須ルール（DESIGN.md から派生）
+### 必須ルール（DESIGN.md v2 から派生）
 
-- **カラー**: 任意の hex を直書きしない。`styles/tokens.css` のセマンティックエイリアス（`--surface-*` / `--text-*` / `--border-*` / `--action-*`）または Tailwind の対応クラス（`bg-paper`, `text-primary` 等）を使う。
-- **影**: ソフト/ブラー影は禁止（`shadow-sm/md/lg/xl/2xl` 等）。許容は `--shadow-hard`（4px 4px 0 0 インク、ぼかしなし）のみ、インタラクティブカードの hover に限る。
+- **カラー**: 任意の hex を直書きしない。モノクローム（warm tint）の primary/neutral ランプ（50–950）とシグナルカラー（success / warning / danger / info）のトークン経由で使う。シグナル以外の有彩色を持ち込まない。
+- **インタラクション状態**: hover = 明度 −5%、active = 明度 −10%、focus = 2px solid primary + offset 2px、disabled = opacity 40%。値をハードコードせず導出ルールとして適用する。
+- **影**: `--shadow-sm/md/lg/xl` の4段のみ（subtle、中立ブラック）。エレベーションは dropdown (sm) < card (md) < modal (lg) < toast (xl)。この4段以外の影・色付き影は作らない。
 - **グラデーション禁止**。
-- **角丸は 0–6px**。`rounded-pill`（999px）はタグ・アバターのみ。`rounded-lg/2xl/3xl/full` を一般 UI に使わない。
-- **タイポ**: 見出し = Space Grotesk、本文 = DM Sans、JP = Noto Sans JP、mono ラベルは大文字 + 0.16em tracking。
+- **角丸**: トークン（sm 4px / md 8px / lg 12px / xl 16px / full）経由。コンポーネントロールで参照する: input = sm、button = md、card = lg、badge = full。px 直書き禁止。
+- **タイポ**: Inter 単一ファミリー（JP フォールバックに Noto Sans JP）。ベース 16px、スケール比 1.2。ロールは h1–h4 / body / caption（DESIGN.md §3 の値が正）。
 - **Emoji 禁止**（UI / コピー / コメント全てで）。状態は Badge / ドットで表す。
-- **リンク色**: `--hazard #BB6A35` のみ。それ以外の色（blue 等）でリンクを描画しない。
-- **余白**: セクション縦リズム 64–128px。ぎゅっと詰めない。
+- **リンク色**: `primary-700` + 下線（DESIGN.md §11 A2）。有彩色（blue 等）でリンクを描画しない。
+- **余白**: 8px ベースのリニアスケール。セクション間は `3xl`（64px）、ブロック内スタックは `md`（16px）。
+- **ダークモード**: 対応必須。ランプ共通で役割を反転（背景 950、本文 200 等）。
 - **Voice**: 一人称・単数 "I"。マーケ語（leverage / synergy / best-in-class）禁止。誇張・感嘆禁止。
 
 ### 乖離の扱い

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,196 +1,221 @@
-# アフロ Design System — DESIGN.md
+# アフロ Design System v2 — DESIGN.md
 
-**金城将太郎（アフロ / Kinjo Shotaro）** のパーソナルブランド・デザインシステム。
+**金城翔太郎（アフロ / Kinjo Shotaro）** のパーソナルブランド・デザインシステム。
 小さく鋭い SaaS プロダクトを複数手がけるフルスタックエンジニア。TypeScript / React / Next.js。
-キーボードを離れれば、ランエボ・スキー・旅。
 
-> 素材は **アスファルト・コンクリート・紙**。静かで、工業的で、控えめ。
-> 路面と紙のような手触り、彩度はほぼゼロ、余白はたっぷり、角丸は最小。
-> **グラデーションも影も使わない。** 自信は声量ではなく、抑制で示す。
+> **v2（2026-07 刷新）**: pre-design-md で生成したトークンスペックを正とする。
+> 方向性は **モノクローム（微かな暖色ティント）**。ヒエラルキーは色相ではなく明度で作る。
+> フォントは **Inter** 一族に統一。影は「使わない」から「subtle に使う」へ転換。
+> v1（asphalt / paper / Space Grotesk / 影禁止）は本バージョンで全面置き換え。
 
 ---
 
 ## 1. ブランドの基本（Content Fundamentals）
 
+ビジュアルは刷新するが、声は変えない。
+
 | 項目 | 指針 |
 |---|---|
 | **Voice** | 一人称・単数。"I build SaaS." 顔の見えない "we" ではなく、常に人がいるパーソナルブランド。 |
 | **Tone** | 静かな自信、控えめ。事実を淡々と述べ、そのまま立たせる。誇張も感嘆もしない。 |
-| **Casing** | 見出し・本文はセンテンスケース。**大文字は mono のマイクロラベルだけ**（アイブロウ、メタ情報、スペックキー、フッター）。そこでは 0.16em のワイドトラッキング。 |
+| **Casing** | 見出し・本文はセンテンスケース。大文字マイクロラベルは caption ロールで使う場合のみ。 |
 | **Brevity** | 短文。リズムのための体言止め・断片も可。形容詞は2つ目を削る。 |
-| **Bilingual** | 日本語は英語と自然に同居（ワードマーク「アフロ」、タグ「ランエボ・スキー・旅」、日本語読者向けの本文）。装飾としてではなく、意味を持つ場所にだけ。 |
-| **Numbers** | 控えめな証拠として少数の正直な数字（"5 products shipped", "100% TypeScript"）。虚栄の指標の壁は作らない。 |
+| **Bilingual** | 日本語は英語と自然に同居。装飾としてではなく、意味を持つ場所にだけ。 |
+| **Numbers** | 控えめな証拠として少数の正直な数字。虚栄の指標の壁は作らない。 |
 | **Emoji** | 使わない。プロダクトでもコピーでも。状態は Badge とドットで表す。 |
-| **Vocabulary** | 素朴な職人言葉 — "ship", "build", "the line", "stack"。マーケ語（leverage / synergy / best-in-class）は避ける。 |
-
-ヒーローコピー例：
-*"Kinjo Shotaro — full-stack engineer shipping a handful of small, sharp SaaS products.
-TypeScript front to back. Off the keyboard: a Lancer Evolution, spring corn snow, and a one-way ticket somewhere."*
+| **Vocabulary** | 素朴な職人言葉 — "ship", "build", "stack"。マーケ語（leverage / synergy / best-in-class）は避ける。 |
 
 ---
 
 ## 2. カラー（Color）
 
-彩度ほぼゼロの暖色ニュートラル。**フラットのみ、グラデーション禁止。**
+**モノクローム（warm tint, warmth 0.25）**。ほぼ見えない程度の暖色ティントを持つグレースケールで、ヒエラルキーは明度が担う。hex 値は OKLCH ソースから導出したもの。**以下の値が正。再導出しない。**
 
-### 2.1 素材アンカー
-| トークン | 値 | 役割 |
+### 2.1 Primary / Neutral ランプ
+
+このシステムでは primary と neutral は同一のランプ（モノクロームの意図そのもの）。役割で使い分ける。
+
+| ステップ | 値 | 主な役割（ライト時） |
 |---|---|---|
-| `--asphalt` | `#302F2C` | 暗いサーフェス / 主インク |
-| `--concrete` | `#8A8680` | 中間点 — 二次テキスト、ボーダー、ディバイダー |
-| `--paper` | `#EFEDE3` | 明るいサーフェス / 紙のストック |
+| `50` | `#fafafa` | ページ背景 |
+| `100` | `#f2f2f1` | 面の持ち上げ / hover 背景 |
+| `200` | `#dfdedd` | ボーダー / ディバイダー |
+| `300` | `#c5c4c2` | 強めのボーダー / 無効ボーダー |
+| `400` | `#a6a4a3` | プレースホルダ / 三次テキスト |
+| `500` | `#878684` | **primary** / 二次テキスト |
+| `600` | `#6a6867` | primary hover 相当 |
+| `700` | `#4e4d4c` | primary active 相当 / 強めテキスト |
+| `800` | `#343332` | 見出し・本文テキスト |
+| `900` | `#1b1a1a` | 最強調テキスト / 反転面 |
+| `950` | `#0b0b0b` | ダーク時のページ背景 |
 
-### 2.2 ニュートラル・ランプ（暖色・低彩度 16 段）
-`--neutral-950 #1B1A18` → `--neutral-900` → `--neutral-850` → **`--neutral-800 #302F2C`（= ASPHALT）** →
-`--neutral-700` → `--neutral-600` → `--neutral-500` → **`--neutral-450 #8A8680`（= CONCRETE）** →
-`--neutral-400` → `--neutral-300` → `--neutral-250` → `--neutral-200` → `--neutral-150` →
-**`--neutral-100 #EFEDE3`（= PAPER）** → `--neutral-50` → `--neutral-0 #FAF8F0`
+### 2.2 シグナルカラー（低彩度のまま）
 
-> ランプの値は**塗り**に使う。コンポーネントでは**セマンティックエイリアス**を参照する。
-
-### 2.3 シグナルトーン（控えめに、低彩度のまま）
 | トークン | 値 | 意味 |
 |---|---|---|
-| `--signal-positive` | `#5C6E54` | lichen green |
-| `--signal-caution` | `#9C7B3F` | ochre / desaturated hazard |
-| `--signal-critical` | `#92503F` | oxide rust-red |
-| `--signal-info` | `#4F6470` | slate blue |
+| `success` | `#6b8a6b` | 成功 |
+| `warning` | `#b8a17c` | 注意 |
+| `danger` | `#a0736f` | 失敗 / 破壊的操作 |
+| `info` | `#61859f` | 情報 |
 
-主に Badge の輪郭やステータスドットとして。塗りとして使うのは稀。
+Badge・ステータスドット・アラートなど意味を持つ場所だけに使う。装飾には使わない。
 
-### 2.4 アクセント — Hazard（リンクとホバー専用）
-| トークン | 値 | 用途 |
-|---|---|---|
-| `--hazard` / `--accent` / `--link` | `#BB6A35` | 焦げた琥珀。**インラインリンク、nav リンクのホバー、カード矢印のホバー、フッターリンクのホバーのみ。** |
-| `--hazard-deep` / `--accent-hover` | `#A85A2B` | ホバー / プレス |
-| （Asphalt 文脈） | `#CF8348` / `#DD9358` | 暗背景では可読性のため少し持ち上げる |
+### 2.3 インタラクション状態（導出ルール）
 
-> Primary ボタン・タブ・選択チップは**インク（asphalt）のまま**。アクセントが主役（うるさい要素）にならないようにする。
+状態色はハードコードせず、以下のルールを手続き的に適用する:
 
-### 2.5 セマンティックエイリアス（コンポーネントで使う）
-- **サーフェス**: `--surface-page` / `--surface-raised` / `--surface-sunken` / `--surface-card` / `--surface-inverse`
-- **テキスト**: `--text-primary` / `--text-secondary` / `--text-tertiary` / `--text-disabled` / `--text-on-inverse`
-- **ボーダー**: `--border-strong`（CONCRETE）/ `--border-default` / `--border-subtle` / `--divider`
-- **アクション**: `--action-primary-*`（インク on 紙）/ `--action-secondary-*` / `--action-ghost-*` / `--focus-ring`
+- `hover`: 明度 −5%
+- `active`: 明度 −10%
+- `focus`: 2px solid `primary`、offset 2px
+- `disabled`: opacity 40%
 
-### 2.6 2つの文脈（Surface contexts）
-- 既定の **Paper（明）** と **Asphalt（暗）** の2文脈。`data-theme="asphalt"` で切り替え。
-- 同じトークン名で値だけ反転。フッターや反転パネルに使用。
+### 2.4 ダークモード
+
+ダークモード対応はスペックの一部。ランプは共通で、役割を反転して使う（背景 `950`、面 `900`、ボーダー `800`、本文 `200`、強調 `50`）。シグナルカラーは共通。
+
+### 2.5 禁止事項
+
+- 任意の hex 直書き禁止。トークン経由で使う。
+- グラデーション禁止（v1 から継続）。
+- シグナルカラー以外の有彩色を持ち込まない。
 
 ---
 
 ## 3. タイポグラフィ（Type）
 
-| ロール | フォント | 設定 |
-|---|---|---|
-| **Display / Headings** | `--font-display` = **Space Grotesk** (500–700) | 大サイズで letter-spacing −0.02〜−0.03em、センテンスケース |
-| **Body / UI** | `--font-body` = **DM Sans** (400–600) | line-height 1.5（UI）〜 1.7（prose） |
-| **Mono / Labels / Code** | `--font-mono` = システム mono スタック（webfont なし） | アイブロウ・メタ・スペックキー。大文字 + 0.16em |
-| **Japanese** | `--font-jp` = **Noto Sans JP** (400/500/700) | 全ファミリーのフォールバックに含み、JP と Latin を綺麗に同居 |
+**Inter 単一ファミリー**。中立で密度が高く、どこでも通用する。見出しと本文で書体を分けない（統一感を書体の共有で作る）。ベース 16px、モジュラースケール比 **1.2（minor third）**。
 
-### 3.1 スケール（1.250 major-third, 11px → 88px）
-`--size-3xs 11px`（micro）/ `--size-2xs 12px` / `--size-xs 13px` / `--size-sm 14px` /
-`--size-md 16px`（base body）/ `--size-lg 18px` / `--size-xl 22px`（H4）/ `--size-2xl 28px`（H3）/
-`--size-3xl 36px`（H2）/ `--size-4xl 48px`（H1）/ `--size-5xl 64px`（display）/ `--size-6xl 88px`（hero）
+| ロール | サイズ | ウェイト | 行間 |
+|---|---|---|---|
+| `h1` | 2.4883rem | 700 | 1.3 |
+| `h2` | 2.0736rem | 700 | 1.3 |
+| `h3` | 1.728rem | 700 | 1.3 |
+| `h4` | 1.44rem | 700 | 1.3 |
+| `body` | 1rem | 400 | 1.6 |
+| `caption` | 0.8333rem | 400 | 1.6 |
 
-> 本文の最小は 16px、マイクロラベルは 11–12px。
-
-### 3.2 行間・字間
-- Line-height: `--leading-tight 1.05` / `--leading-snug 1.18` / `--leading-normal 1.5` / `--leading-relaxed 1.7`
-- Tracking: `--tracking-tight −0.02em` / `--tracking-snug −0.01em` / `--tracking-wide 0.08em` / `--tracking-wider 0.16em`
-
-### 3.3 合成ロール
-`--text-display` / `--text-h1` / `--text-h2` / `--text-h3` / `--text-body-lg` / `--text-body` / `--text-mono`
+フォントスタック: `'Inter', system-ui, -apple-system, sans-serif`（全ロール共通）。
 
 ---
 
-## 4. スペーシング & レイアウト（Spacing & Layout）
+## 4. スペーシング（Spacing）
 
-たっぷりの余白が署名。セクションは呼吸する（縦リズム 64–128px）。
+ベース **8px、リニアスケール**。慣れたウェブのリズムで、互換性と密度の予測可能性を優先。
 
-- **スケール**（4px base, 8px rhythm）: `--space-1 4` / `-2 8` / `-3 12` / `-4 16` / `-5 24` / `-6 32` / `-7 48` / `-8 64` / `-9 96` / `-10 128` / `-11 192`
-- **コンテナ**: `--container-prose 68ch` / `--container-narrow 720px` / `--container-content 1080px` / `--container-wide 1320px` / `--gutter = --space-5`
-- インラインフローではなく **flex / grid + `gap`** を全面採用。
+| トークン | 値 |
+|---|---|
+| `2xs` | 4px |
+| `xs` | 8px |
+| `sm` | 12px |
+| `md` | 16px |
+| `lg` | 24px |
+| `xl` | 32px |
+| `2xl` | 48px |
+| `3xl` | 64px |
+| `4xl` | 96px |
+| `5xl` | 128px |
+
+- 主要ブロック間（セクション区切り）: `3xl`
+- ブロック内のスタック間隔: `md`
 
 ---
 
-## 5. ボーダー・角丸・深度（Borders, Radius, Depth）
+## 5. 角丸（Rounded）
 
-- **角丸は最小（0–6px）**: `--radius-xs 2` / `-sm 3` / `--radius-md 4`（コントロール・カード既定）/ `-lg 6` / `--radius-pill 999`（タグ・アバターのみ）。スクエアで工業的。
-- **ボーダーが構造を担う**: 既定 1px ハードライン `--border-default`、強調に CONCRETE `--border-strong`、エディトリアルな区切り・選択状態に 2–3px のインク罫（`--border-thick 2` / `--border-rule 3`）。
-- **影は使わない。** 深度はボーダー・サーフェスのコントラスト・余白から。唯一許される持ち上げは、フラットな**ハードオフセット** `--shadow-hard: 4px 4px 0 0` インク（ぼかしなし）。インタラクティブなカードのホバーのみ。ソフト/ブラー影は禁止。
+ベース 8px（friendly and modern）、スケール展開。コンポーネントごとに役割を変え、形で機能を伝える: 入力はシャープに、カードはやわらかく。
+
+| トークン | 値 |
+|---|---|
+| `none` | 0 |
+| `sm` | 4px |
+| `md` | 8px |
+| `lg` | 12px |
+| `xl` | 16px |
+| `full` | 9999px |
+
+### コンポーネント別ロール
+
+| コンポーネント | 参照トークン |
+|---|---|
+| `input` | `rounded.sm` (4px) |
+| `button` | `rounded.md` (8px) |
+| `card` | `rounded.lg` (12px) |
+| `badge` | `rounded.full` |
+
+新しいコンポーネントを足すときも px 直書きせず、ロールとして `rounded` トークンを参照する。
 
 ---
 
-## 6. モーション（Motion）
+## 6. 影（Shadow）
 
-- 抑制的。**120–320ms**、`--ease-standard cubic-bezier(0.2,0,0.2,1)`。
+v1 の「影禁止」を廃止。**subtle** な中立ブラック（ティントなし）の影で深度を表す。
+
+```css
+--shadow-sm: 0 1px 2px 0 oklch(0% 0 0 / 0.06);
+--shadow-md: 0 4px 6px -1px oklch(0% 0 0 / 0.08), 0 2px 4px -2px oklch(0% 0 0 / 0.08);
+--shadow-lg: 0 10px 15px -3px oklch(0% 0 0 / 0.1), 0 4px 6px -4px oklch(0% 0 0 / 0.1);
+--shadow-xl: 0 20px 25px -5px oklch(0% 0 0 / 0.12), 0 8px 10px -6px oklch(0% 0 0 / 0.12);
+```
+
+エレベーション階層: `dropdown` (sm) < `card` (md) < `modal` (lg) < `toast` (xl)。
+
+この4段以外の影を作らない。強い影・色付き影は禁止。
+
+---
+
+## 7. モーション（Motion）— v1 から継続
+
+スペックの対象外のため v1 の方針を維持する。
+
+- 抑制的。**120–320ms**、`cubic-bezier(0.2, 0, 0.2, 1)`。
 - バウンスなし、スプリングなし、無限ループなし。
-- ホバー = 色 / ボーダーのシフト。プレス = 1px 下に translate。タブの下線は左からスケールイン。
+- ホバー = 色 / ボーダーのシフト（§2.3 の導出ルールに従う）。
 - `prefers-reduced-motion` を尊重。
-- トークン: `--duration-fast 120ms` / `--duration-normal 200ms` / `--duration-slow 320ms` / `--ease-standard` / `--ease-out`
 
 ---
 
-## 7. アイコノグラフィ（Iconography）
+## 8. アイコノグラフィ（Iconography）— v1 から継続
 
-- **システム**: [Lucide](https://lucide.dev) — 細い **1.5px** ストローク、スクエアな linecap、24×24 グリッド。機械的で抑制された線質が工業的なトーンに合う。CDN（`unpkg.com/lucide`）から読み込み、レンダー後に `lucide.createIcons()` を呼ぶ。`currentColor` を継承。
-- **代替フラグ**: Lucide は「選んだ」マッチであり既存のブランド資産ではない。別セットに差し替えても可 — 細く・スクエアな・モノラインの性格を保つこと。
-- **Emoji**: アイコンにもコピーにも一切使わない。
-- **Unicode**: アイコノグラフィに使わない。状態は Lucide グリフか Badge ドットで。
-- 共通セット: ski / car / travel / build / ship / stack / link / status（`guidelines/iconography.card.html`）。
+- **システム**: [Lucide](https://lucide.dev)。細い 1.5px ストローク、24×24 グリッド、`currentColor` 継承。
+- **Emoji / 装飾 Unicode**: アイコンにもコピーにも使わない。状態は Lucide グリフか Badge ドットで。
 
 ---
 
-## 8. コンポーネント（Components）
+## 9. 使用ガイドライン（Usage）
 
-ロード後、各コンポーネントは `window.DesignSystem_83d653` に公開される。
-
-```html
-<link rel="stylesheet" href="_ds/<folder>/tokens/fonts.css">
-<link rel="stylesheet" href="_ds/<folder>/tokens/colors.css">
-<link rel="stylesheet" href="_ds/<folder>/tokens/typography.css">
-<link rel="stylesheet" href="_ds/<folder>/tokens/spacing.css">
-<link rel="stylesheet" href="_ds/<folder>/tokens/base.css">
-<link rel="stylesheet" href="_ds/<folder>/styles.css">
-<script src="_ds/<folder>/_ds_bundle.js"></script>
-```
-
-`window.React` / `window.ReactDOM` を先に読み込むこと。バンドルは通常の `<script>`（`type="text/babel"` も `module` も不要）。
-
-| コンポーネント | 説明 | 例 |
-|---|---|---|
-| **Button** | ブランドの主アクション。インク on 紙、スクエア、影なし。`variant`: primary / secondary、`size`: sm 等 | `<Button variant="primary">Ship it</Button>` |
-| **IconButton** | ラベルなしの正方形アクション（ツールバー） | `<IconButton aria-label="Close"><X /></IconButton>` |
-| **Input** | ラベル・ヒント・アイコン・エラー状態付き 1 行テキスト | `<Input label="Email" type="email" required />` |
-| **Switch** | バイナリ on/off。スクエアなトラック、紙のサム | `<Switch label="Dark surface" defaultChecked />` |
-| **Card** (+ `Card.Body`) | ボーダー付きサーフェス。静止時は影なし、任意のハードオフセット lift。`interactive` / `lift` / `rule` | `<Card><h3>Ran Evo</h3></Card>` |
-| **Badge** | 小さなステータス / カテゴリマーカー。mono、大文字、スクエア。`variant`: solid / positive…、`dot` | `<Badge variant="positive" dot>Live</Badge>` |
-| **Tag** | フィルタ・キーワード用ピル。選択可・削除可 | `<Tag active onClick={toggle}>React</Tag>` |
-| **Tabs** | 水平セクション切替。underline / enclosed（pill） | `<Tabs value={tab} onChange={setTab} … />` |
-
-```jsx
-const { Button, Card, Badge, Tag, Tabs, Input, Switch, IconButton } = window.DesignSystem_83d653;
-```
-
-### カードのバリエーション
-- 既定: `--surface-card` + 1px `--border-default`、4px 角丸、静止時影なし。
-- `interactive`: ホバーで CONCRETE ボーダー。
-- `lift`: ホバーでハードオフセット影。
-- `rule`: 全周ボーダーを 1 本の重いインク上罫に差し替え（エディトリアル）。
+- Primary アクションは `primary` を使い、hover で `primary-600`、active で `primary-700` に落とす。
+- Card は `card` の角丸ロール + `--shadow-md`。
+- Button は `button` の角丸ロール。primary バリアントには `--shadow-sm`。
+- Input は `input` の角丸ロール。フォーカスリングは §2.3 に従う。
+- 本文は `body` タイポグラフィロール。
+- セクション間は `3xl`、ブロック内スタックは `md`。
 
 ---
 
-## 9. UI キット & 参照
+## 10. AI 向け生成指示（Generation instructions）
 
-- `ui_kits/portfolio/` — アフロのパーソナル SaaS ポートフォリオ（hero / work grid / project detail / writing / about + contact）。クリックスルー可、上記コンポーネントを構成。
-- `guidelines/*.card.html` — Colors / Type / Spacing / Brand の仕様カード（Design System タブ）。
-- ワードマークは純粋にタイポグラフィ的 — ロゴマークは不要。
+1. 本書の値を正とする。好みで再導出しない。
+2. 必要な値がリストにないときは、最も近い既存トークンを選ぶ。
+3. 新しい決定が必要になったら、§11 に追記して明示的にフラグを立てる。
+4. 根拠コメント（rationale）はデザイン意図のエンコードなので保持する。
+5. インタラクション状態はハードコードされた値ではなく導出ルール（§2.3）。手続き的に適用する。
 
 ---
 
-## 10. 注意点（Caveats）
+## 11. 追加決定事項（Appended decisions — スペック外）
 
-- **フォントは CDN 配信**（自前ホストではない）。`tokens/fonts.css` が Space Grotesk + DM Sans + Noto Sans JP を Google Fonts から `@import`。mono はOSスタック。オフライン/自前ホストが必要なら `.woff2` を入れて `@import` をローカル `@font-face` に置換。
-- コードベース / Figma / ライブサイトは**提供されていない**。ブランドブリーフから起こしたもの。UI キットのサンプル内容（プロジェクト名・コピー・数値）は**説明用**であり、実素材に差し替えること。
-- Voice / Tone とアイコノグラフィは推定を含む。実物のサイトやリポジトリがあれば突き合わせ可能。
+スペックが定めていない領域について、本リポジトリで下した決定。**いずれもスペック由来ではない**ため、変更する場合はここを書き換えれば良い。
+
+| # | 決定 | 内容 | 根拠 |
+|---|---|---|---|
+| A1 | **日本語フォント** | Inter のフォールバックに **Noto Sans JP** を挟む: `'Inter', 'Noto Sans JP', system-ui, ...` | スペックは Latin のみ想定。日本語本文があるサイトのため。 |
+| A2 | **リンク色** | 本文中のリンクは `primary-700` + 下線。hover は §2.3 の導出ルール。 | スペックにリンク定義なし。モノクロームの意図を守るため有彩色を足さず、明度と下線で区別する。 |
+| A3 | **マイクロラベル** | v1 の mono 大文字ラベル（アイブロウ等）は `caption` ロール + 大文字 + 0.08em tracking で代替。等幅フォントは使わない。 | Inter 単一ファミリーの原則を優先。 |
+
+---
+
+## 12. 移行メモ（v1 → v2）
+
+- 実装（`styles/tokens.css` / `tailwind.config.ts` / 各コンポーネント）はまだ v1 ベース。乖離は `docs/design-gap.md` で追跡し、新規実装・リファクタ時に v2 へ寄せる。
+- v1 の特徴的ルールで**廃止**されたもの: 影禁止（→ §6 の4段階）、角丸 0–6px（→ §5）、hazard `#BB6A35` リンク色（→ A2）、Space Grotesk / DM Sans（→ Inter）、mono マイクロラベル（→ A3）。
+- **継続**するもの: グラデーション禁止、Emoji 禁止、低彩度シグナルカラー、Voice / Tone、モーションの抑制、Lucide。

--- a/docs/design-gap.md
+++ b/docs/design-gap.md
@@ -1,120 +1,45 @@
-# Design Gap — 既存コード vs `DESIGN.md`
+# Design Gap — 既存コード vs `DESIGN.md` v2
 
 `DESIGN.md`（SSoT）と現在の実装の乖離一覧。新規実装・リファクタ時はここを潰す方向で進める。
-**重要度**: 🔴 違反（DESIGN.md 明示禁止）/ 🟡 推奨外（指針外れ）/ 🟢 改善余地
 
-最終更新: 2026-06-08
-
----
-
-## 1. グローバル / レイアウト
-
-| 場所 | 現状 | DESIGN.md ルール | 重要度 |
-|---|---|---|---|
-| `pages/layout.tsx:35` | `bg-gray-50` (cool gray) | 暖色ニュートラルのみ。`bg-surface-page` 相当 (`--paper #EFEDE3`) を使う | 🔴 |
-| `styles/globals.css` | Google Fonts 読み込みなし、html へのフォント指定なし | Space Grotesk / DM Sans / Noto Sans JP を CSS 経由でロードし、body は DM Sans | 🔴（→ tokens 導入で解決済） |
-| サーフェス・テキスト・ボーダー | hex / tailwind 標準色直書き | セマンティックエイリアス（`surface-*` / `ink-*` / `line-*`）経由 | 🔴 |
+最終更新: 2026-07-23（DESIGN.md v2 刷新に伴い全面書き換え）
 
 ---
 
-## 2. コンポーネント
+## 前提
 
-### `components/Button.tsx`
-```tsx
-bg-slate-500 hover:bg-slate-700 text-white py-2 px-4 rounded
-```
-- 🔴 cool gray（`slate-*`）を使用 → DESIGN.md は暖色ニュートラル限定。Primary は **インク (asphalt) on 紙 (paper)**。
-- 🔴 `rounded`（4px Tailwind 既定だが意図不明）→ `rounded-md`（= 4px トークン）を明示。
-- 🟡 variant / size プロップ未対応 → DESIGN.md §8 で `variant: primary/secondary`、`size: sm` を期待。
-- 🟡 hover が背景色トーン変更 → DESIGN.md §6 では「色 / ボーダーのシフト」+「プレスで 1px 下に translate」を期待。
+2026-07 に `DESIGN.md` が v2（モノクローム warm tint / Inter / subtle shadow）へ刷新された。
+**実装は全面的に v1 以前の状態**であり、v1 時代の個別監査（cool gray 混入等）は本ファイルの旧版（git 履歴）を参照。現状のギャップは「実装全体が v2 未対応」に集約される。
 
-### `components/Header.tsx`
-- 🔴 `bg-slate-200 rounded-2xl` でアクティブナビを表現 → 16px radius は DESIGN.md（最大 6px）違反。色も cool gray。
-- 🟡 アクティブ表現は **2–3px のインク罫**（`--border-rule`）か Tabs underline が DESIGN.md の方向性。
-- 🟡 nav リンクの hover に hazard を出していない（DESIGN.md §2.4：nav の hover で hazard を使う）。
+## v2 移行ギャップ（大分類）
 
-### `components/Footer.tsx`
-- 🟢 機能的には問題なし。フォントロールが mono のマイクロラベルに置き換わるべき（コピーライト・リンクは mono + 大文字 + 0.16em tracking が DESIGN.md §1）。
-- 🟡 「&copy; kinjo shotaro 2024年」は固定年。動的化推奨。
+| # | 領域 | 現状 | v2 のあるべき姿 | 対象 |
+|---|---|---|---|---|
+| 1 | カラートークン | v1 トークン（`--asphalt` / `--paper` / hazard 等）+ 一部 cool gray 直書き | primary/neutral ランプ（50–950, warm tint）+ シグナル4色に置換 | `styles/tokens.css`, `tailwind.config.ts`, 全コンポーネント |
+| 2 | タイポグラフィ | Space Grotesk + DM Sans（v1）、一部フォント未指定 | Inter 単一ファミリー（+ Noto Sans JP fallback）、スケール比 1.2、h1–h4 / body / caption ロール | `styles/`, `components/Heading.tsx`, prose |
+| 3 | 影 | v1 の影禁止前提（`shadow-hard` / 影なし）と、逆に Tailwind 標準 `shadow-lg` 直書きの混在 | `--shadow-sm/md/lg/xl` の4段（subtle）+ エレベーション階層 | tokens, Card 系, blog / products 一覧 |
+| 4 | 角丸 | 0–6px（v1）と `rounded-2xl` 等の直書き混在 | トークン（4/8/12/16px + full）+ コンポーネントロール（input=sm / button=md / card=lg / badge=full） | 全コンポーネント |
+| 5 | インタラクション状態 | 個別クラスで hover 色をハードコード | 導出ルール（hover −5% / active −10% / focus ring / disabled 40%）を仕組みで適用 | tokens + 共通コンポーネント |
+| 6 | リンク色 | v1 hazard `#BB6A35` 前提 + 一部 `text-blue-*` | `primary-700` + 下線（DESIGN.md §11 A2） | グローバル CSS, products/[id] |
+| 7 | ダークモード | 未対応（v1 の Asphalt 文脈も未実装） | ランプ役割反転による対応必須（DESIGN.md §2.4） | tokens, layout |
+| 8 | スペーシング | 個別 margin（`my-3` 等）が散在 | 8px リニアスケール。セクション間 `3xl`、スタック `md` | layout, pages |
 
-### `components/Tooltip.tsx`
-- 🔴 `bg-black text-white` → 黒は使わない。`asphalt` (`#302F2C`) + `paper` テキストへ。
-- 🔴 `rounded`（Tailwind 既定）→ `rounded-md` トークン明示。
+## v1 から引き続き有効な指摘
 
-### `components/Heading.tsx`
-- 🟡 `font-bold` 固定 → DESIGN.md は Space Grotesk 500–700。h1 で `font-display font-semibold` 推奨。
-- 🟡 サイズマッピングが意図的タイポスケールでない（`text-2xl/xl/lg/md/sm/xs` の素直な対応） → `--text-h1/h2/h3` 合成ロールに合わせる。
-- 🟡 `my-3` 固定 → セクション縦リズム 64–128px 思想と合わない。マージン管理は親側に寄せる。
+- Emoji / 感嘆符コピー（blog の「いいね！」等）は v2 でも禁止。文言調整が必要。
+- Voice & Tone（一人称 I、誇張禁止）のコピー乖離（index / about）はリライト対象のまま。
+- アイコンの Lucide 統一（1.5px stroke / 24×24、`ICON_SIZE=60` 廃止）も継続。
 
-### `components/Achievement.tsx`, `MembershipList.tsx`
-- 🟢 文言はシンプルで OK。
-- 🟡 リスト見出しが Heading コンポーネント経由 → タイポロール整備後に再評価。
+## 推奨される段階的移行プラン（v2）
 
-### `components/SNS.tsx`
-- 🟡 ICON_SIZE=60 とトークン外の数値。アイコンは Lucide の 24×24 グリッド + 1.5px stroke（DESIGN.md §7）を踏襲。デカすぎる気配。
-- 🟡 SVG を直書き（speakerdeck）→ Lucide にないなら別アイコンセットでも可（細・スクエア・モノラインを保つ）。
+1. **基盤** — `styles/tokens.css` を v2 トークン（ランプ / シグナル / 影 / 角丸 / タイポ / スペーシング）で書き直し、`tailwind.config.ts` を接続
+2. **状態の仕組み化** — hover / active / focus / disabled の導出ルールをユーティリティ化
+3. **共通コンポーネント刷新** — Button / Card / Input / Badge / Heading / Tooltip / Header を v2 ロールで書き直し
+4. **ページ移行** — pages/* を新トークン・新コンポーネントへ差し替え、直書き色と Tailwind 標準影を一掃
+5. **ダークモード** — ランプ反転の実装と切り替え
+6. **コピー刷新** — Voice & Tone ガイドでリライト
 
----
-
-## 3. ページ
-
-### `pages/index.tsx`
-- 🔴 `text-gray-400` → cool gray。`text-ink-tertiary` (`--text-tertiary` = concrete) に。
-- 🟡 プロフィール画像 `rounded-lg` → 写真にも角丸最小（0–6px）。`rounded-md` か **角丸なし**（工業的）が望ましい。
-- 🟡 ヒーローコピーがブランドガイドの「一人称・単数の I」「事実淡々」と一致していない。`DESIGN.md §1` のヒーローコピー例に寄せる。
-
-### `pages/about.tsx`
-- 🟡 段落が長く Voice ガイド（短文・体言止め・形容詞 1 つ）と乖離。リライト対象。
-- 🟡 「Coming soon...」放置。プロダクトとして弱いので埋める or セクションごと隠す。
-
-### `pages/blog/index.tsx`
-- 🔴 `shadow-lg`（ソフト影）→ 影禁止。`lift` バリアントが必要なら `shadow-hard` のみ。
-- 🔴 `rounded overflow-hidden border-2` の組み合わせは grid カードとして DESIGN.md の `Card` 仕様に置き換え。
-- 🔴 `hover:border-gray-400` → cool gray。`hover:border-line-strong`（CONCRETE）に。
-- 🔴 `text-gray-400` → ink-tertiary。
-
-### `pages/blog/[id].tsx`
-- 🟡 「いいね！」ボタン文言に `！` 全角感嘆 + 絵文字感。DESIGN.md §1（誇張・感嘆禁止）。`Like` か `いいね` に。
-- 🟡 prose は `tailwind/typography` 標準のまま → DESIGN.md のフォント/字間/行間に合わせて `prose` カスタマイズが必要。
-
-### `pages/products/index.tsx`
-- 🔴 `shadow-lg` 影、`rounded` cool gray border-hover。blog 同様。
-- 🟡 `Card` コンポーネント未抽出。`DESIGN.md §8` の `Card` に置き換える。
-
-### `pages/products/[id].tsx`
-- 🔴 `text-blue-600 hover:text-blue-800` → リンク色は `--hazard #BB6A35` のみ。
-- 🟡 「作品 URL」見出しなど h3 を Heading コンポーネント経由にしていない。
-
-### `pages/work/index.tsx`
-- 🔴 `text-slate-400` → cool gray。`text-ink-tertiary`。
-- 🟡 期間表示は mono の小文字大文字（micro label）に。日付フォーマットも DESIGN.md の "FROM / TO" 表記に揃える余地。
-
----
-
-## 4. トークン未使用箇所のサマリ
-
-| カテゴリ | 違反箇所数 | 対応 |
-|---|---|---|
-| cool gray (`slate-*`, `gray-*`) | 8 箇所 | `ink-*` / `line-*` / `surface-*` へ置換 |
-| `shadow-lg` | 2 箇所 | 削除、必要時のみ `shadow-hard` |
-| `rounded-2xl`, `rounded-lg` (UI コントロール) | 3 箇所 | `rounded-md`（4px） |
-| リンク色 (`text-blue-*`) | 1 箇所 | `<a>` 既定 hazard で OK（クラス削除） |
-| Emoji / 絵文字感のあるコピー | 1 箇所（"いいね！"） | 文言調整 |
-
----
-
-## 5. 推奨される段階的移行プラン
-
-1. **基盤** — `styles/tokens.css` 導入 + Tailwind 接続 ✅ 済
-2. **共通コンポーネント刷新** — `Button` / `Card`（新規）/ `Tooltip` / `Header` / `Heading` を DESIGN.md §8 仕様で書き直し
-3. **ページ移行** — pages/* を新コンポーネントに差し替え、cool gray を一掃
-4. **prose スタイル** — blog 本文の typography をブランドフォントに揃える
-5. **コピー刷新** — index / about / blog タイトル等を Voice & Tone ガイドでリライト
-6. **アイコン整理** — Lucide 1.5px stroke / 24×24 を共通化、ICON_SIZE 廃止
-
----
-
-## 6. 参照
+## 参照
 
 - SSoT: `../DESIGN.md`
 - トークン定義: `../styles/tokens.css`


### PR DESCRIPTION
## 概要

UI刷新の第一歩として、pre-design-md で生成したトークンスペックを `DESIGN.md` v2 として取り込んだ。実装の変更は含まない（スペックのみ）。

## 変更内容

### DESIGN.md（全面書き換え）
- **カラー**: モノクローム（warm tint）の primary/neutral ランプ 50–950 + シグナル4色。hex はスペックの値をそのまま採用
- **タイポ**: Inter 単一ファミリー、ベース16px・スケール比1.2、h1–h4 / body / caption
- **スペーシング**: 8pxベースのリニアスケール（2xs–5xl）
- **角丸**: 4/8/12/16px + full。コンポーネントロール（input=sm / button=md / card=lg / badge=full）
- **影**: v1の影禁止を廃止し、subtle 4段 + エレベーション階層
- **インタラクション状態**: hover −5% / active −10% / focus ring / disabled 40% の導出ルール
- スペック対象外の Voice / モーション / アイコノグラフィは v1 から継続
- スペックにない決定（JPフォント / リンク色 / マイクロラベル）は §11「追加決定事項」としてフラグ付きで分離

### .claude/CLAUDE.md
- 「必須ルール（DESIGN.md から派生）」を v2 の内容に同期

### docs/design-gap.md
- v1 前提の個別監査を、v2 移行ギャップの大分類 + 移行プランに全面書き換え（旧版は git 履歴参照）

## 次のステップ（別PR）

- `styles/tokens.css` / `tailwind.config.ts` の v2 トークン実装
- 共通コンポーネント・ページの移行、ダークモード対応