### PR TITLE
feat: デザインシステム v2 を実装

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,12 +1,30 @@
 type Props = {
-  children: React.ReactNode;
-  className?: string;
-  handleClick?: () => void;
+	children: React.ReactNode;
+	className?: string;
+	variant?: "primary" | "secondary";
+	handleClick?: () => void;
 };
-export default function Button({ children, className, handleClick }:Props) {
-  return (
-    <button type="button" onClick={handleClick} className={`bg-slate-500 hover:bg-slate-700 text-white font-bold py-2 px-4 rounded ${className}`}>
-      {children}
-    </button>
-  );
+
+const VARIANT_CLASS = {
+	primary:
+		"bg-[var(--action-primary-bg)] text-[var(--action-primary-fg)] hover:bg-[var(--action-primary-bg-hover)] active:bg-[var(--action-primary-bg-active)] shadow-sm",
+	secondary:
+		"bg-transparent text-ink-primary border border-line-strong hover:bg-surface-raised active:bg-surface-sunken",
+} as const;
+
+export default function Button({
+	children,
+	className,
+	variant = "primary",
+	handleClick,
+}: Props) {
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			className={`rounded-button px-4 py-2 font-medium transition-colors duration-fast disabled:opacity-40 disabled:pointer-events-none ${VARIANT_CLASS[variant]} ${className ?? ""}`}
+		>
+			{children}
+		</button>
+	);
 }

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,21 +1,21 @@
 import React from "react";
 
 interface TooltipProps {
-  text: string;
-  children: React.ReactNode;
+	text: string;
+	children: React.ReactNode;
 }
 
 const Tooltip: React.FC<TooltipProps> = ({ text, children }) => {
-  return (
-    <div className="group relative flex items-center">
-      {children}
-      <div className="absolute top-full w-10 mt-2 hidden group-hover:block">
-        <div className="bg-black text-white text-xs rounded py-1 px-2 min-w-max left-0 transform translate">
-          {text}
-        </div>
-      </div>
-    </div>
-  );
+	return (
+		<div className="group relative flex items-center">
+			{children}
+			<div className="absolute top-full w-10 mt-2 hidden group-hover:block">
+				<div className="bg-surface-inverse text-ink-on-inverse text-xs rounded-sm shadow-sm py-1 px-2 min-w-max left-0">
+					{text}
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default Tooltip;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -66,7 +66,7 @@ export default function Home({
 						</p>
 
 						<h1
-							className="jp-display font-black leading-[0.92] tracking-tighter ink-settle"
+							className="jp-display font-bold leading-tight tracking-tight ink-settle"
 							style={{
 								fontSize: "clamp(40px, 12vw, 192px)",
 							}}

--- a/pages/layout.tsx
+++ b/pages/layout.tsx
@@ -50,7 +50,7 @@ export default function Layout({
 					<section className="pt-12 md:pt-16 lg:pt-20 pb-12 lg:pb-16">
 						<div className="flex items-start justify-between gap-6">
 							<h1
-								className="jp-display font-black leading-[0.95] tracking-tighter ink-settle"
+								className="jp-display font-bold leading-tight tracking-tight ink-settle"
 								style={{ fontSize: "clamp(32px, 8vw, 120px)" }}
 							>
 								{title}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,5 @@
 @import "./tokens.css";
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;700;800;900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap");
 
 @tailwind base;
 @tailwind components;
@@ -12,35 +12,17 @@
     font-family: var(--font-body);
     font-size: var(--size-md);
     line-height: var(--leading-normal);
-    font-feature-settings: "kern", "liga", "calt", "onum";
+    font-feature-settings: "kern", "liga", "calt";
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
-    /* prevent horizontal scroll caused by hero clamp + paddings on narrow screens */
     overflow-x: clip;
   }
 
-  body {
-    overflow-x: clip;
-  }
-
-  /* Paper texture: loose-leaf horizontal rule + grain, scrolls with content */
   body {
     background-color: var(--surface-page);
     color: var(--text-primary);
-    background-image:
-      repeating-linear-gradient(
-        to bottom,
-        transparent 0,
-        transparent calc(var(--rule-gap) - 1px),
-        var(--rule-color) calc(var(--rule-gap) - 1px),
-        var(--rule-color) var(--rule-gap)
-      ),
-      url("/textures/paper-grain.svg");
-    background-size: auto, 320px 320px;
-    background-attachment: scroll;
-    background-position: top left;
-    background-repeat: repeat, repeat;
+    overflow-x: clip;
   }
 
   h1,
@@ -48,13 +30,12 @@
   h3,
   h4 {
     font-family: var(--font-display);
-    letter-spacing: var(--tracking-tight);
     line-height: var(--leading-snug);
-    color: var(--text-primary);
+    color: var(--text-heading);
     font-weight: 700;
   }
 
-  /* Japanese display uses mincho — only when explicitly opted in */
+  /* JP 見出し (Noto Sans JP 明示) */
   .jp-display {
     font-family: var(--font-jp-display);
     font-weight: 700;
@@ -69,43 +50,39 @@
   }
 
   a:hover {
-    color: var(--accent-hover);
+    color: var(--link-hover);
+  }
+
+  /* Focus ring: 2px solid primary, offset 2px (DESIGN.md §2.3) */
+  :focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+  }
+
+  :disabled {
+    opacity: 0.4;
   }
 
   ::selection {
-    background-color: var(--ink);
-    color: var(--paper);
+    background-color: var(--surface-inverse);
+    color: var(--text-on-inverse);
   }
 
-  /* Small caps utility for captions — uses clean sans for legibility */
+  /* Micro label: caption + uppercase + 0.08em (DESIGN.md §11 A3) */
   .small-caps {
-    font-family: var(--font-sans);
-    font-variant-caps: all-small-caps;
-    letter-spacing: var(--tracking-wider);
-    font-feature-settings: "smcp", "c2sc";
+    font-family: var(--font-body);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
   }
 
-  /* Tabular numerals for index numbers — also uses sans */
+  /* Tabular numerals for index numbers */
   .tnum {
-    font-family: var(--font-sans);
+    font-family: var(--font-body);
     font-variant-numeric: tabular-nums;
-  }
-
-  /* Optical sizes for Newsreader */
-  .display {
-    font-family: var(--font-display);
-    font-optical-sizing: auto;
-    font-variation-settings: "opsz" 72;
-  }
-
-  /* Vertical Japanese writing (used selectively) */
-  .vertical {
-    writing-mode: vertical-rl;
-    font-family: var(--font-jp-display);
   }
 }
 
-/* ---- Editorial animations ---- */
+/* ---- Animations (restrained — DESIGN.md §7) ---- */
 @keyframes fadeUp {
   from {
     opacity: 0;
@@ -126,17 +103,6 @@
   }
 }
 
-@keyframes inkSettle {
-  0% {
-    opacity: 0;
-    letter-spacing: 0.05em;
-  }
-  100% {
-    opacity: 1;
-    letter-spacing: var(--tracking-tight);
-  }
-}
-
 .page-enter {
   animation: fadeUp var(--duration-slow) var(--ease-editorial) forwards;
 }
@@ -146,41 +112,37 @@
 }
 
 .page-enter > *:nth-child(1) { animation-delay: 0ms; }
-.page-enter > *:nth-child(2) { animation-delay: 80ms; }
-.page-enter > *:nth-child(3) { animation-delay: 160ms; }
-.page-enter > *:nth-child(4) { animation-delay: 240ms; }
-.page-enter > *:nth-child(5) { animation-delay: 320ms; }
-.page-enter > *:nth-child(6) { animation-delay: 400ms; }
-.page-enter > *:nth-child(n + 7) { animation-delay: 480ms; }
+.page-enter > *:nth-child(2) { animation-delay: 60ms; }
+.page-enter > *:nth-child(3) { animation-delay: 120ms; }
+.page-enter > *:nth-child(4) { animation-delay: 180ms; }
+.page-enter > *:nth-child(5) { animation-delay: 240ms; }
+.page-enter > *:nth-child(6) { animation-delay: 300ms; }
+.page-enter > *:nth-child(n + 7) { animation-delay: 360ms; }
 
+.ink-settle {
+  animation: fadeUp var(--duration-slow) var(--ease-editorial) both;
+}
+
+/* v1 のテクスチャ背景は廃止。プレーンなサーフェスのみ */
 .home-plain-paper {
   background-color: var(--surface-page);
-  background-image: url("/textures/paper-grain.svg");
-  background-size: 320px 320px;
-  background-attachment: scroll;
-  background-position: top left;
-  background-repeat: repeat;
 }
 
 /* Decorative rule that animates in */
 .rule-line {
   display: block;
   height: 1px;
-  background-color: var(--ink);
+  background-color: var(--border-strong);
   transform-origin: left center;
   animation: drawRule var(--duration-slow) var(--ease-editorial) forwards;
 }
 
-.ink-settle {
-  animation: inkSettle var(--duration-slow) var(--ease-editorial) both;
-}
-
-/* Editorial prose overrides for markdown body */
+/* ---- Prose (markdown body) ---- */
 .prose {
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 16px;
-  line-height: 1.85;
+  font-size: var(--size-md);
+  line-height: 1.8;
 }
 
 .prose p {
@@ -189,54 +151,47 @@
 }
 
 .prose h2 {
-  font-family: var(--font-jp-display);
-  font-weight: 900;
-  font-size: 1.625rem;
+  font-weight: 700;
+  font-size: var(--size-2xl);
+  line-height: var(--leading-snug);
   margin-top: 2.5em;
   margin-bottom: 0.6em;
   padding-top: 1em;
   border-top: 1px solid var(--rule-color);
-  letter-spacing: var(--tracking-tight);
 }
 
 .prose h3 {
-  font-family: var(--font-jp-display);
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: var(--size-xl);
+  line-height: var(--leading-snug);
   margin-top: 2em;
   margin-bottom: 0.6em;
-  letter-spacing: var(--tracking-tight);
 }
 
 .prose h4 {
-  font-family: var(--font-jp-display);
   font-weight: 700;
-  font-size: 1.05rem;
+  font-size: var(--size-lg);
   margin-top: 1.6em;
   margin-bottom: 0.4em;
 }
 
 .prose a {
-  color: var(--text-primary);
+  color: var(--link);
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 0.2em;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .prose a:hover {
-  background-color: var(--ink);
-  color: var(--paper);
-  text-decoration-color: transparent;
+  color: var(--link-hover);
 }
 
 .prose blockquote {
-  border-left: 2px solid var(--ink);
+  border-left: 2px solid var(--border-strong);
   padding-left: 1em;
   font-style: normal;
-  font-family: var(--font-jp-display);
-  font-weight: 500;
-  color: var(--text-primary);
+  color: var(--text-secondary);
   margin: 1.5em 0;
 }
 
@@ -246,17 +201,8 @@
   margin: 1em 0;
 }
 
-.prose ul > li {
-  list-style: none;
-  position: relative;
-}
-
-.prose ul > li::before {
-  content: "—";
-  position: absolute;
-  left: -1.4em;
-  color: var(--text-secondary);
-  font-weight: 600;
+.prose ul {
+  list-style: disc;
 }
 
 .prose ol {
@@ -268,24 +214,30 @@
   margin: 0.4em 0;
 }
 
+.prose li::marker {
+  color: var(--text-tertiary);
+}
+
 .prose code {
   background: var(--surface-sunken);
   padding: 0.12em 0.4em;
   font-family: var(--font-mono);
   font-size: 0.92em;
   font-weight: 500;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
 }
 
 .prose pre {
-  background: var(--ink);
-  color: var(--paper);
+  background: var(--surface-inverse);
+  color: var(--text-on-inverse);
   padding: 1.2em 1.4em;
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: 0.9em;
   line-height: 1.6;
   margin: 1.5em 0;
+  border-radius: var(--radius-md);
 }
 
 .prose pre code {
@@ -303,7 +255,8 @@
 
 .prose img {
   margin: 2em 0;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
 }
 
 .prose table {
@@ -315,20 +268,20 @@
 
 .prose th,
 .prose td {
-  border-bottom: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-default);
   padding: 0.6em 0.8em;
   text-align: left;
 }
 
 .prose th {
   font-weight: 700;
-  font-family: var(--font-sans);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-wide);
   font-size: 0.85em;
+  color: var(--text-secondary);
 }
 
-/* Editorial link hover: drawn underline */
+/* Link hover: drawn underline */
 .link-draw {
   position: relative;
   text-decoration: none;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,130 +1,117 @@
 /*
- * Design Tokens — Editorial Paper
+ * Design Tokens — v2 (monochrome, warm tint)
  * SSoT: ../DESIGN.md
  * 直接 hex を書かず、ここで定義されたトークン経由で参照する。
+ * hex は OKLCH ソースから導出済みの値 (DESIGN.md §2)。再導出しない。
  */
 
 :root {
-  /* ---- Neutral ramp (cool warm-tinged paper grey) ---- */
-  --neutral-950: #131210;
-  --neutral-900: #1a1815;
-  --neutral-850: #232220;
-  --neutral-800: #2c2a27; /* = INK */
-  --neutral-700: #494742;
-  --neutral-600: #6b6862;
-  --neutral-500: #8a8680;
-  --neutral-450: #9d9a94; /* = CONCRETE */
-  --neutral-400: #b6b3ac;
-  --neutral-300: #c5c2bb;
-  --neutral-250: #d0cfc8; /* = RULE */
-  --neutral-200: #e7e6e1;
-  --neutral-150: #efeeea;
-  --neutral-100: #f3f2ef; /* = PAPER (closer to white) */
-  --neutral-50: #f7f6f3;
-  --neutral-0: #fbfaf8;
+  /* ---- Neutral / Primary ramp (DESIGN.md §2.1) ---- */
+  --neutral-50: #fafafa;
+  --neutral-100: #f2f2f1;
+  --neutral-200: #dfdedd;
+  --neutral-300: #c5c4c2;
+  --neutral-400: #a6a4a3;
+  --neutral-500: #878684;
+  --neutral-600: #6a6867;
+  --neutral-700: #4e4d4c;
+  --neutral-800: #343332;
+  --neutral-900: #1b1a1a;
+  --neutral-950: #0b0b0b;
 
-  /* ---- Material anchors ---- */
-  --ink: var(--neutral-800);
-  --asphalt: var(--neutral-800); /* alias for legacy refs */
-  --concrete: var(--neutral-450);
-  --paper: var(--neutral-100);
-  --rule: var(--neutral-250);
+  --primary: var(--neutral-500);
+  --primary-hover: var(--neutral-600);
+  --primary-active: var(--neutral-700);
 
-  /* ---- Signal tones ---- */
-  --signal-positive: #5c6e54;
-  --signal-caution: #9c7b3f;
-  --signal-critical: #92503f;
-  --signal-info: #4f6470;
+  /* ---- Material aliases (テーマで反転しない・リテラル) ---- */
+  --paper: var(--neutral-50);
+  --asphalt: var(--neutral-900);
+  --concrete: var(--neutral-500);
 
-  /* ---- Accent (used sparingly, links only) ---- */
-  --hazard: #2c2a27;
-  --hazard-deep: #000000;
-  --accent: var(--hazard);
-  --accent-hover: var(--hazard-deep);
-  --link: var(--hazard);
+  /* ---- Signals (DESIGN.md §2.2) ---- */
+  --signal-positive: #6b8a6b;
+  --signal-caution: #b8a17c;
+  --signal-critical: #a0736f;
+  --signal-info: #61859f;
 
-  /* ---- Semantic aliases ---- */
-  --surface-page: var(--paper);
-  --surface-raised: var(--neutral-50);
-  --surface-sunken: var(--neutral-150);
-  --surface-card: var(--neutral-0);
-  --surface-inverse: var(--ink);
+  /* ---- Semantic aliases (テーマで反転する) ---- */
+  --surface-page: var(--neutral-50);
+  --surface-raised: var(--neutral-100);
+  --surface-sunken: var(--neutral-100);
+  --surface-card: var(--neutral-50);
+  --surface-inverse: var(--neutral-900);
 
-  --text-primary: var(--ink);
-  --text-secondary: var(--neutral-700);
-  --text-tertiary: var(--neutral-600);
+  --text-primary: var(--neutral-800);
+  --text-heading: var(--neutral-900);
+  --text-secondary: var(--neutral-600);
+  --text-tertiary: var(--neutral-500);
   --text-disabled: var(--neutral-400);
-  --text-on-inverse: var(--paper);
+  --text-on-inverse: var(--neutral-50);
 
-  --border-strong: var(--neutral-500);
-  --border-default: var(--neutral-300);
-  --border-subtle: var(--neutral-200);
-  --divider: var(--rule);
-  --border-thick: 2px;
-  --border-rule: 1px;
+  --border-strong: var(--neutral-300);
+  --border-default: var(--neutral-200);
+  --border-subtle: var(--neutral-100);
+  --divider: var(--neutral-200);
 
-  --action-primary-bg: var(--ink);
-  --action-primary-fg: var(--paper);
-  --action-primary-bg-hover: var(--neutral-900);
+  /* リンク: primary-700 + 下線 (DESIGN.md §11 A2)。hover は明度 −5% 相当をランプで近似 */
+  --link: var(--neutral-700);
+  --link-hover: var(--neutral-800);
+
+  /* アクション: primary を使い hover→600 / active→700 (DESIGN.md §9) */
+  --action-primary-bg: var(--primary);
+  --action-primary-fg: var(--neutral-50);
+  --action-primary-bg-hover: var(--primary-hover);
+  --action-primary-bg-active: var(--primary-active);
   --action-secondary-bg: transparent;
-  --action-secondary-fg: var(--ink);
-  --action-secondary-border: var(--ink);
-  --action-ghost-bg: transparent;
-  --action-ghost-fg: var(--ink);
-  --focus-ring: var(--ink);
+  --action-secondary-fg: var(--text-primary);
+  --action-secondary-border: var(--border-strong);
+  --focus-ring: var(--primary);
 
-  /* ---- Type scale ---- */
-  --size-3xs: 11px;
-  --size-2xs: 12px;
-  --size-xs: 13px;
-  --size-sm: 14px;
-  --size-md: 16px;
-  --size-lg: 19px;
-  --size-xl: 24px;
-  --size-2xl: 32px;
-  --size-3xl: 44px;
-  --size-4xl: 60px;
-  --size-5xl: 84px;
-  --size-6xl: 120px;
-  --size-7xl: 168px;
+  /* ---- Type scale (base 16px, ratio 1.2 — DESIGN.md §3) ---- */
+  --size-3xs: 0.5787rem;
+  --size-2xs: 0.6944rem;
+  --size-xs: 0.6944rem;
+  --size-sm: 0.8333rem; /* caption */
+  --size-md: 1rem; /* body */
+  --size-lg: 1.2rem;
+  --size-xl: 1.44rem; /* h4 */
+  --size-2xl: 1.728rem; /* h3 */
+  --size-3xl: 2.0736rem; /* h2 */
+  --size-4xl: 2.4883rem; /* h1 */
+  --size-5xl: 2.986rem;
+  --size-6xl: 3.5832rem;
 
   /* ---- Leading & tracking ---- */
-  --leading-tight: 0.95;
-  --leading-snug: 1.12;
-  --leading-normal: 1.6;
-  --leading-relaxed: 1.8;
+  --leading-tight: 1.1;
+  --leading-snug: 1.3; /* headings */
+  --leading-normal: 1.6; /* body */
+  --leading-relaxed: 1.75;
   --tracking-tight: -0.02em;
   --tracking-snug: -0.01em;
   --tracking-normal: 0;
-  --tracking-wide: 0.08em;
-  --tracking-wider: 0.18em;
+  --tracking-wide: 0.08em; /* micro labels (DESIGN.md §11 A3) */
+  --tracking-wider: 0.08em;
 
-  /* ---- Fonts ---- */
-  /* Noto Sans family for clarity and legibility, JP + Latin matched. */
-  --font-display: "Noto Sans", "Noto Sans JP", "Hiragino Kaku Gothic ProN",
-    "Yu Gothic", system-ui, sans-serif;
-  --font-body: "Noto Sans", "Noto Sans JP", "Hiragino Kaku Gothic ProN",
-    "Yu Gothic", system-ui, sans-serif;
-  --font-jp-display: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic",
-    sans-serif;
+  /* ---- Fonts (Inter 単一ファミリー + Noto Sans JP fallback — §3 / §11 A1) ---- */
+  --font-body: "Inter", "Noto Sans JP", system-ui, -apple-system, sans-serif;
+  --font-display: var(--font-body);
   --font-jp: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic",
     sans-serif;
-  --font-sans: "Noto Sans", "Noto Sans JP", system-ui, sans-serif;
+  --font-jp-display: var(--font-jp);
+  --font-sans: var(--font-body);
   --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
-  --font-small-caps: "Noto Sans", sans-serif;
 
-  /* ---- Spacing scale (4px base / 8px rhythm) ---- */
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --space-5: 24px;
-  --space-6: 32px;
-  --space-7: 48px;
-  --space-8: 64px;
-  --space-9: 96px;
-  --space-10: 128px;
-  --space-11: 192px;
+  /* ---- Spacing (8px base, linear — DESIGN.md §4) ---- */
+  --space-1: 4px; /* 2xs */
+  --space-2: 8px; /* xs */
+  --space-3: 12px; /* sm */
+  --space-4: 16px; /* md — ブロック内スタック */
+  --space-5: 24px; /* lg */
+  --space-6: 32px; /* xl */
+  --space-7: 48px; /* 2xl */
+  --space-8: 64px; /* 3xl — セクション間 */
+  --space-9: 96px; /* 4xl */
+  --space-10: 128px; /* 5xl */
 
   /* ---- Containers ---- */
   --container-prose: 64ch;
@@ -133,56 +120,107 @@
   --container-wide: 1320px;
   --gutter: var(--space-5);
 
-  /* ---- Loose-leaf rule grid ---- */
-  --rule-gap: 32px;
-  --rule-color: rgba(20, 20, 18, 0.1);
+  /* ---- Radius (base 8px, scaled — DESIGN.md §5) ---- */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-pill: 9999px;
+  /* コンポーネントロール */
+  --radius-input: var(--radius-sm);
+  --radius-button: var(--radius-md);
+  --radius-card: var(--radius-lg);
+  --radius-badge: var(--radius-pill);
 
-  /* ---- Radius (editorial: no rounding) ---- */
-  --radius-xs: 0;
-  --radius-sm: 0;
-  --radius-md: 0;
-  --radius-lg: 0;
-  --radius-pill: 999px;
+  /* ---- Shadows (subtle, neutral black — DESIGN.md §6) ---- */
+  /* elevation: dropdown (sm) < card (md) < modal (lg) < toast (xl) */
+  --shadow-sm: 0 1px 2px 0 oklch(0% 0 0 / 0.06);
+  --shadow-md: 0 4px 6px -1px oklch(0% 0 0 / 0.08),
+    0 2px 4px -2px oklch(0% 0 0 / 0.08);
+  --shadow-lg: 0 10px 15px -3px oklch(0% 0 0 / 0.1),
+    0 4px 6px -4px oklch(0% 0 0 / 0.1);
+  --shadow-xl: 0 20px 25px -5px oklch(0% 0 0 / 0.12),
+    0 8px 10px -6px oklch(0% 0 0 / 0.12);
 
-  /* ---- Depth ---- */
-  --shadow-hard: 4px 4px 0 0 var(--ink);
-
-  /* ---- Motion ---- */
-  --duration-fast: 160ms;
-  --duration-normal: 280ms;
-  --duration-slow: 520ms;
+  /* ---- Motion (DESIGN.md §7) ---- */
+  --duration-fast: 120ms;
+  --duration-normal: 200ms;
+  --duration-slow: 320ms;
   --ease-standard: cubic-bezier(0.2, 0, 0.2, 1);
   --ease-out: cubic-bezier(0, 0, 0.2, 1);
   --ease-editorial: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* ---- Prose rule color ---- */
+  --rule-color: var(--border-default);
 }
 
-/* ---- Dark / inverse context ---- */
-[data-theme="ink"] {
-  --surface-page: var(--ink);
-  --surface-raised: var(--neutral-850);
+/* ---- Dark mode (ランプ共通・役割反転 — DESIGN.md §2.4) ---- */
+[data-theme="dark"] {
+  --surface-page: var(--neutral-950);
+  --surface-raised: var(--neutral-900);
   --surface-sunken: var(--neutral-900);
-  --surface-card: var(--neutral-850);
-  --surface-inverse: var(--paper);
+  --surface-card: var(--neutral-900);
+  --surface-inverse: var(--neutral-50);
 
-  --text-primary: var(--paper);
-  --text-secondary: var(--neutral-300);
-  --text-tertiary: var(--neutral-450);
+  --text-primary: var(--neutral-200);
+  --text-heading: var(--neutral-50);
+  --text-secondary: var(--neutral-400);
+  --text-tertiary: var(--neutral-500);
   --text-disabled: var(--neutral-600);
-  --text-on-inverse: var(--ink);
+  --text-on-inverse: var(--neutral-900);
 
-  --border-strong: var(--neutral-500);
-  --border-default: var(--neutral-700);
-  --border-subtle: var(--neutral-800);
-  --divider: var(--neutral-700);
+  --border-strong: var(--neutral-600);
+  --border-default: var(--neutral-800);
+  --border-subtle: var(--neutral-900);
+  --divider: var(--neutral-800);
 
-  --rule-color: rgba(245, 243, 235, 0.08);
+  --link: var(--neutral-300);
+  --link-hover: var(--neutral-200);
 
-  --action-primary-bg: var(--paper);
-  --action-primary-fg: var(--ink);
-  --action-primary-bg-hover: var(--neutral-50);
-  --action-secondary-fg: var(--paper);
-  --action-secondary-border: var(--paper);
-  --action-ghost-fg: var(--paper);
+  --action-primary-bg: var(--neutral-200);
+  --action-primary-fg: var(--neutral-900);
+  --action-primary-bg-hover: var(--neutral-300);
+  --action-primary-bg-active: var(--neutral-400);
+  --action-secondary-fg: var(--text-primary);
+  --action-secondary-border: var(--border-strong);
+  --focus-ring: var(--neutral-300);
+
+  --rule-color: var(--neutral-800);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+    --surface-page: var(--neutral-950);
+    --surface-raised: var(--neutral-900);
+    --surface-sunken: var(--neutral-900);
+    --surface-card: var(--neutral-900);
+    --surface-inverse: var(--neutral-50);
+
+    --text-primary: var(--neutral-200);
+    --text-heading: var(--neutral-50);
+    --text-secondary: var(--neutral-400);
+    --text-tertiary: var(--neutral-500);
+    --text-disabled: var(--neutral-600);
+    --text-on-inverse: var(--neutral-900);
+
+    --border-strong: var(--neutral-600);
+    --border-default: var(--neutral-800);
+    --border-subtle: var(--neutral-900);
+    --divider: var(--neutral-800);
+
+    --link: var(--neutral-300);
+    --link-hover: var(--neutral-200);
+
+    --action-primary-bg: var(--neutral-200);
+    --action-primary-fg: var(--neutral-900);
+    --action-primary-bg-hover: var(--neutral-300);
+    --action-primary-bg-active: var(--neutral-400);
+    --action-secondary-fg: var(--text-primary);
+    --action-secondary-border: var(--border-strong);
+    --focus-ring: var(--neutral-300);
+
+    --rule-color: var(--neutral-800);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,7 @@ import type { Config } from "tailwindcss";
 
 /**
  * Tailwind theme is wired to CSS variables defined in styles/tokens.css.
- * SSoT for design decisions: DESIGN.md
+ * SSoT for design decisions: DESIGN.md (v2 — monochrome warm tint)
  */
 const config: Config = {
   content: [
@@ -13,32 +13,32 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        // Material anchors
+        // Material aliases (literal, do not flip with theme)
         asphalt: "var(--asphalt)",
         concrete: "var(--concrete)",
         paper: "var(--paper)",
 
-        // Neutral ramp
+        // Monochrome ramp (DESIGN.md §2.1)
         neutral: {
-          0: "var(--neutral-0)",
           50: "var(--neutral-50)",
           100: "var(--neutral-100)",
-          150: "var(--neutral-150)",
           200: "var(--neutral-200)",
-          250: "var(--neutral-250)",
           300: "var(--neutral-300)",
           400: "var(--neutral-400)",
-          450: "var(--neutral-450)",
           500: "var(--neutral-500)",
           600: "var(--neutral-600)",
           700: "var(--neutral-700)",
           800: "var(--neutral-800)",
-          850: "var(--neutral-850)",
           900: "var(--neutral-900)",
           950: "var(--neutral-950)",
         },
+        primary: {
+          DEFAULT: "var(--primary)",
+          hover: "var(--primary-hover)",
+          active: "var(--primary-active)",
+        },
 
-        // Signals
+        // Signals (DESIGN.md §2.2)
         signal: {
           positive: "var(--signal-positive)",
           caution: "var(--signal-caution)",
@@ -46,17 +46,7 @@ const config: Config = {
           info: "var(--signal-info)",
         },
 
-        // Accent
-        hazard: {
-          DEFAULT: "var(--hazard)",
-          deep: "var(--hazard-deep)",
-        },
-        accent: {
-          DEFAULT: "var(--accent)",
-          hover: "var(--accent-hover)",
-        },
-
-        // Semantic aliases
+        // Semantic aliases (flip with theme)
         surface: {
           page: "var(--surface-page)",
           raised: "var(--surface-raised)",
@@ -66,6 +56,7 @@ const config: Config = {
         },
         ink: {
           primary: "var(--text-primary)",
+          heading: "var(--text-heading)",
           secondary: "var(--text-secondary)",
           tertiary: "var(--text-tertiary)",
           disabled: "var(--text-disabled)",
@@ -76,6 +67,10 @@ const config: Config = {
           DEFAULT: "var(--border-default)",
           subtle: "var(--border-subtle)",
           divider: "var(--divider)",
+        },
+        link: {
+          DEFAULT: "var(--link)",
+          hover: "var(--link-hover)",
         },
       },
       fontFamily: {
@@ -122,7 +117,6 @@ const config: Config = {
         8: "var(--space-8)",
         9: "var(--space-9)",
         10: "var(--space-10)",
-        11: "var(--space-11)",
       },
       maxWidth: {
         prose: "var(--container-prose)",
@@ -130,23 +124,29 @@ const config: Config = {
         content: "var(--container-content)",
         wide: "var(--container-wide)",
       },
+      // Radius tokens + component roles (DESIGN.md §5)
       borderRadius: {
         none: "0",
-        xs: "var(--radius-xs)",
         sm: "var(--radius-sm)",
         md: "var(--radius-md)",
         DEFAULT: "var(--radius-md)",
         lg: "var(--radius-lg)",
+        xl: "var(--radius-xl)",
         pill: "var(--radius-pill)",
+        full: "var(--radius-pill)",
+        input: "var(--radius-input)",
+        button: "var(--radius-button)",
+        card: "var(--radius-card)",
+        badge: "var(--radius-badge)",
       },
-      borderWidth: {
-        DEFAULT: "1px",
-        thick: "var(--border-thick)",
-        rule: "var(--border-rule)",
-      },
+      // Subtle shadows only, elevation: dropdown < card < modal < toast (DESIGN.md §6)
       boxShadow: {
         none: "none",
-        hard: "var(--shadow-hard)",
+        sm: "var(--shadow-sm)",
+        md: "var(--shadow-md)",
+        DEFAULT: "var(--shadow-md)",
+        lg: "var(--shadow-lg)",
+        xl: "var(--shadow-xl)",
       },
       transitionDuration: {
         fast: "var(--duration-fast)",


### PR DESCRIPTION
## 概要

DESIGN.md v2（モノクローム warm tint / Inter / subtle shadow）をコードに実装する。design-gap.md の移行プラン 1〜5 に相当。

## 変更内容

### styles/tokens.css
- ランプを v2 の 50–950（warm tint）に置き換え。primary = neutral-500
- シグナル4色、subtle 影4段（sm/md/lg/xl）、角丸トークン + コンポーネントロール（input/button/card/badge）
- タイポを Inter + 1.2 スケールに変更、モーションを 120/200/320ms に短縮
- セマンティックエイリアス名（surface-* / text-* / border-*）は維持し、ページ側の変更を最小化
- **ダークモード追加**: `prefers-color-scheme` 自動追従 + `data-theme="dark" / "light"` 上書き

### tailwind.config.ts
- 新ランプ・primary・影・角丸ロール（rounded-input/button/card/badge）を接続

### styles/globals.css
- フォントを Inter + Noto Sans JP に変更（Space Grotesk / DM Sans / 紙テクスチャ廃止）
- focus ring（2px primary + offset 2px）と disabled opacity 40% をグローバル適用
- マイクロラベルを uppercase + 0.08em に（DESIGN.md §11 A3）、prose を v2 トークンで再構成

### コンポーネント
- Button: slate 直書きを廃止し、primary/secondary バリアント + 状態則で再実装
- Tooltip: bg-black 直書きを廃止し、surface-inverse + shadow-sm + rounded-sm に
- 見出しの font-black(900) を v2 の 700 に統一（Inter は 400–700 のみロード）

## 検証

- `pnpm build` 成功（全39ページ生成）
- ローカルで `/` と `/work` をブラウザ確認。ライト・ダーク両モードでランプ反転を確認済み