### PR TITLE
fix: navのBlog表記をWritingに統一

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,7 +5,7 @@ const NAV = [
 	{ href: "/about", label: "About" },
 	{ href: "/work", label: "Work" },
 	{ href: "/products", label: "Products" },
-	{ href: "/blog", label: "Blog" },
+	{ href: "/blog", label: "Writing" },
 	{ href: "/tools", label: "Tools" },
 ];
 

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -24,9 +24,9 @@ export default function Blog({
 	return (
 		<Layout title="Writing">
 			<SeoHead
-				title="Blog"
+				title="Writing"
 				titleTemplate="Top"
-				description="Blogの一覧ページです"
+				description="記事の一覧ページです"
 				imgUrl="/favicon.ico"
 			/>
 


### PR DESCRIPTION
## Summary
ナビの「Blog」をクリックするとページ見出しが「Writing」と表示され、表記が一致していなかった。サイト内はトップページ (Recent — Writing / see all writing) と Blog ページ見出しがすでに「Writing」のため、多数派の「Writing」に統一する。

## Changes
- `components/Header.tsx`: ナビラベル `Blog` → `Writing` (URL は `/blog` のまま)
- `pages/blog/index.tsx`: SeoHead の title を `Writing` に統一、description の表記を調整

## Test Plan
- [x] `pnpm build` 成功
- [ ] ナビの「Writing」クリックでページ見出しと一致することを確認