### PR TITLE
feat: Work詳細ページに目次を追加

### DIFF
--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -47,7 +47,6 @@ export const TableOfContents = ({ toc, className }: Props) => {
 
 	return (
 		<nav className={className} aria-label="目次">
-			<p className="text-sm font-medium text-ink-secondary mb-3">目次</p>
 			<ul className="border-l border-line">
 				{toc.map((item) => {
 					const isActive = activeId === item.id;

--- a/pages/work/[slug].tsx
+++ b/pages/work/[slug].tsx
@@ -1,11 +1,14 @@
 import { SeoHead } from "@/components/SeoHead";
+import { TableOfContents } from "@/components/TableOfContents";
 import { formatDate } from "@/libs/common";
 import { getWork, getWorks } from "@/libs/content";
+import { renderToc } from "@/libs/renderDoc";
 import type { Work } from "@/types/work";
 import Link from "next/link";
 import Layout from "../layout";
 
 export default function WorkDetail({ work }: { work: Work }) {
+	const toc = renderToc(work.body);
 	return (
 		<Layout title={work.title} eyebrow="Work">
 			<SeoHead
@@ -17,48 +20,62 @@ export default function WorkDetail({ work }: { work: Work }) {
 
 			<section className="grid grid-cols-12 gap-6 lg:gap-8 pt-8">
 				<aside className="col-span-12 md:col-span-3">
-					<dl className="space-y-4 text-base">
-						<div>
-							<dt className="text-sm font-medium text-ink-secondary">
-								Duration
-							</dt>
-							<dd className="font-semibold text-ink-primary mt-1 tnum">
-								{formatDate(work.fromAt)} —{" "}
-								{work.toAt ? formatDate(work.toAt) : "現在"}
-							</dd>
-						</div>
-						{work.position.length > 0 && (
+					<div className="md:sticky md:top-10 space-y-6">
+						<dl className="space-y-4 text-base">
 							<div>
-								<dt className="text-sm font-medium text-ink-secondary">Role</dt>
-								<dd className="font-semibold text-ink-primary mt-1">
-									{work.position.join(" / ")}
+								<dt className="text-sm font-medium text-ink-secondary">
+									Duration
+								</dt>
+								<dd className="font-semibold text-ink-primary mt-1 tnum">
+									{formatDate(work.fromAt)} —{" "}
+									{work.toAt ? formatDate(work.toAt) : "現在"}
 								</dd>
 							</div>
+							{work.position.length > 0 && (
+								<div>
+									<dt className="text-sm font-medium text-ink-secondary">
+										Role
+									</dt>
+									<dd className="font-semibold text-ink-primary mt-1">
+										{work.position.join(" / ")}
+									</dd>
+								</div>
+							)}
+							<div>
+								<dt className="text-sm font-medium text-ink-secondary">
+									Status
+								</dt>
+								<dd className="mt-1">
+									<span className="inline-block text-xs font-medium text-ink-secondary border border-line rounded-badge px-2 py-0.5">
+										{work.toAt ? "closed" : "ongoing"}
+									</span>
+								</dd>
+							</div>
+							<div>
+								<dt className="text-sm font-medium text-ink-secondary">
+									Company
+								</dt>
+								<dd className="mt-1">
+									<a
+										href={work.link}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="link-draw text-sm font-medium text-ink-primary no-underline"
+									>
+										Visit site →
+									</a>
+								</dd>
+							</div>
+						</dl>
+						{toc.length >= 4 && (
+							<div>
+								<p className="text-sm font-medium text-ink-secondary mb-2">
+									Contents
+								</p>
+								<TableOfContents toc={toc} />
+							</div>
 						)}
-						<div>
-							<dt className="text-sm font-medium text-ink-secondary">Status</dt>
-							<dd className="mt-1">
-								<span className="inline-block text-xs font-medium text-ink-secondary border border-line rounded-badge px-2 py-0.5">
-									{work.toAt ? "closed" : "ongoing"}
-								</span>
-							</dd>
-						</div>
-						<div>
-							<dt className="text-sm font-medium text-ink-secondary">
-								Company
-							</dt>
-							<dd className="mt-1">
-								<a
-									href={work.link}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="link-draw text-sm font-medium text-ink-primary no-underline"
-								>
-									Visit site →
-								</a>
-							</dd>
-						</div>
-					</dl>
+					</div>
 				</aside>
 
 				<article className="col-span-12 md:col-span-9">


### PR DESCRIPTION
## Summary
同じ会社で複数案件を担当しているページ (alive / FourYou / Tavern など) の見通しを良くするため、Work 詳細ページのサイドバーに目次を追加する。会社単位のエントリ構成は維持し、案件はページ内セクションとして見せる方針の一環。

## Changes
- `pages/work/[slug].tsx`: `renderToc` で見出しを抽出し、セクションが4つ以上のページのみサイドバーに Contents (目次) を表示。Blog 詳細と同じ構成でサイドバーを sticky 化
- `components/TableOfContents.tsx`: コンポーネント内部の「目次」ラベルを削除 (呼び出し側の「Contents」ラベルと二重表示になっていたため。Blog 詳細ページも同様に改善される)

## Test Plan
- [x] `pnpm build` 成功
- [x] `/work/alive` (6セクション): Contents が表示され、スクロールで現在地がハイライトされることを確認
- [x] `/work/beenos` (3セクション): 目次が表示されないことを確認
- [ ] `/blog/[id]` で目次ラベルが二重になっていないことを確認

## Additional Notes
description への案件列挙は、複数案件を持つ会社 (tavern / moji / helpfeel / owned / jinen / alive / fouryou) すべてで既に対応済みのため変更なし。