### PR TITLE
fix: Colophonラベルを削除

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -238,11 +238,8 @@ export default function Home({
 						</ul>
 					</section>
 
-					{/* Colophon */}
+					{/* SNS */}
 					<section className="pt-24 lg:pt-32">
-						<p className="text-sm font-medium text-ink-secondary mb-6">
-							Colophon — elsewhere
-						</p>
 						<SNS />
 					</section>
 				</main>


### PR DESCRIPTION
## Summary
トップページ最下部の SNS セクションにあった「Colophon — elsewhere」ラベルを削除する。セクション自体と SNS リンクは維持 (SNS コンポーネント自身の「SNS」見出しが残る)。

## Changes
- `pages/index.tsx`: Colophon ラベルの `<p>` を削除

## Test Plan
- [x] `pnpm build` 成功 (SSG 38ページ生成)