### PR TITLE
feat: GA4計測を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"lint": "biome check ."
 	},
 	"dependencies": {
+		"@next/third-parties": "^16.3.0",
 		"@vercel/og": "^0.6.2",
 		"gray-matter": "^4.0.3",
 		"lucide-react": "^1.29.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,15 @@
 import "@/styles/globals.css";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import type { AppProps } from "next/app";
 
+// GA4 測定 ID (kinjyo.me / ストリーム 2657990993)。測定 ID は公開情報のため直書き。
+const GA_ID = "G-1M4CM8007S";
+
 export default function App({ Component, pageProps }: AppProps) {
-	return <Component {...pageProps} />;
+	return (
+		<>
+			<Component {...pageProps} />
+			<GoogleAnalytics gaId={GA_ID} />
+		</>
+	);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
 
   .:
     dependencies:
+      '@next/third-parties':
+        specifier: ^16.3.0
+        version: 16.3.0(next@16.3.0(@types/node@20.19.21)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@vercel/og':
         specifier: ^0.6.2
         version: 0.6.8
@@ -373,6 +376,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@16.3.0':
+    resolution: {integrity: sha512-cAA96hSI9NC7083b6sEsKjgyvM/YJ2eqXs4HWv8a/z5LE12CL1sUJS+cmcTwNMY4yAFpLyyuZHrMBEfh/4Xupw==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1324,6 +1333,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
@@ -1611,6 +1623,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
+
+  '@next/third-parties@16.3.0(next@16.3.0(@types/node@20.19.21)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      next: 16.3.0(@types/node@20.19.21)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2795,6 +2813,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  third-party-capital@1.0.20: {}
 
   tiny-inflate@1.0.3: {}
 


### PR DESCRIPTION
## Summary
サイトに GA4 の計測が未導入だったため、`@next/third-parties` の `GoogleAnalytics` を `_app.tsx` に追加し、全ページで計測できるようにした。

## Changes
- `@next/third-parties` を追加 (Next.js 公式の GA4 統合)
- `pages/_app.tsx` に `<GoogleAnalytics gaId="G-1M4CM8007S" />` を追加
  - 測定 ID は GA4 プロパティ「ポートフォリオ」(276102493) の kinjyo.me ストリーム (2657990993) のもの
  - 測定 ID は公開情報のため env ではなく直書き

## Test Plan
- [x] `biome check` / `tsc --noEmit` / `pnpm build` がローカルで通ることを確認
- [ ] デプロイ後、GA4 のリアルタイムレポートでページビューが記録されることを確認

## Additional Notes
GA4 側のストリーム URL 設定が `https://kinjyo.me` になっている(実サイトは `https://www.kinjo.me`)。計測には影響しないが、GA 管理画面で直しておくとよい。