### PR TITLE
feat: Vercel Analyticsを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"@next/third-parties": "^16.3.0",
+		"@vercel/analytics": "^2.0.1",
 		"@vercel/og": "^0.6.2",
 		"gray-matter": "^4.0.3",
 		"lucide-react": "^1.29.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import "@/styles/globals.css";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import { Analytics } from "@vercel/analytics/next";
 import type { AppProps } from "next/app";
 
 // GA4 測定 ID (kinjyo.me / ストリーム 2657990993)。測定 ID は公開情報のため直書き。
@@ -10,6 +11,7 @@ export default function App({ Component, pageProps }: AppProps) {
 		<>
 			<Component {...pageProps} />
 			<GoogleAnalytics gaId={GA_ID} />
+			<Analytics />
 		</>
 	);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@next/third-parties':
         specifier: ^16.3.0
         version: 16.3.0(next@16.3.0(@types/node@20.19.21)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.3.0(@types/node@20.19.21)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@vercel/og':
         specifier: ^0.6.2
         version: 0.6.8
@@ -447,6 +450,35 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/og@0.6.8':
     resolution: {integrity: sha512-e4kQK9mP8ntpo3dACWirGod/hHv4qO5JMj9a/0a2AZto7b4persj5YP7t1Er372gTtYFTYxNhMx34jRvHooglw==}
@@ -1692,6 +1724,11 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vercel/analytics@2.0.1(next@16.3.0(@types/node@20.19.21)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    optionalDependencies:
+      next: 16.3.0(@types/node@20.19.21)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
 
   '@vercel/og@0.6.8':
     dependencies:


### PR DESCRIPTION
## Summary
アクセス分析のため `@vercel/analytics` を導入し、全ページで Vercel Web Analytics の計測を有効にした。

## Changes
- `@vercel/analytics` を追加
- `pages/_app.tsx` に `<Analytics />` を追加 (GA4 の `<GoogleAnalytics />` と併用)

## Test Plan
- [x] `biome check` / `tsc --noEmit` / `pnpm build` がローカルで通ることを確認
- [ ] デプロイ後、Vercel ダッシュボードの Analytics タブでページビューが記録されることを確認

## Additional Notes
Vercel 側でプロジェクトの Web Analytics が未有効の場合は、ダッシュボード → portfolio-v4 → Analytics タブから Enable する必要がある(未有効だとスクリプトが 404 になる)。