### PR TITLE
feat: Writing一覧にQiita/Zennの記事を表示

### DIFF
--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -2,25 +2,30 @@ import { SeoHead } from "@/components/SeoHead";
 import { getPublishedDate, isPostWithPath, isPostWithUrl } from "@/libs/common";
 import { getBlogs } from "@/libs/content";
 import type { QiitaPost } from "@/types/Qiita";
-import type { BlogPost, BlogPosts } from "@/types/blog";
+import type { BlogPost } from "@/types/blog";
 import Link from "next/link";
 import Layout from "../layout";
 
-function getHref(post: BlogPost | QiitaPost | ZennPost): string {
+type Post = BlogPost | QiitaPost | ZennPost;
+
+function getHref(post: Post): string {
 	if (isPostWithUrl(post)) return post.url;
-	if (isPostWithPath(post)) return `https://zenn.dev/${post.path}`;
+	if (isPostWithPath(post))
+		return `https://zenn.dev${post.path.startsWith("/") ? "" : "/"}${post.path}`;
 	return `/blog/${post.id}`;
 }
 
-function isExternal(post: BlogPost | QiitaPost | ZennPost): boolean {
+function isExternal(post: Post): boolean {
 	return isPostWithUrl(post) || isPostWithPath(post);
 }
 
-export default function Blog({
-	blog,
-}: {
-	blog: (BlogPost | QiitaPost | ZennPost)[];
-}) {
+function getSource(post: Post): "Qiita" | "Zenn" | null {
+	if (isPostWithUrl(post)) return "Qiita";
+	if (isPostWithPath(post)) return "Zenn";
+	return null;
+}
+
+export default function Blog({ blog }: { blog: Post[] }) {
 	return (
 		<Layout title="Writing">
 			<SeoHead
@@ -43,9 +48,10 @@ export default function Blog({
 						const external = isExternal(post);
 						const href = getHref(post);
 						const published = getPublishedDate(post);
+						const source = getSource(post);
 						return (
 							<li
-								key={post.id}
+								key={`${source ?? "blog"}-${post.id}`}
 								className="grid grid-cols-12 items-baseline gap-3 border-b border-line py-5"
 							>
 								<span className="col-span-1 tnum small-caps text-sm font-medium text-ink-secondary">
@@ -55,10 +61,17 @@ export default function Blog({
 									href={href}
 									target={external ? "_blank" : undefined}
 									rel={external ? "noopener noreferrer" : undefined}
-									className="col-span-8 md:col-span-8 link-draw jp-display text-lg md:text-xl font-medium text-ink-primary no-underline"
+									className="col-span-8 md:col-span-6 link-draw jp-display text-lg md:text-xl font-medium text-ink-primary no-underline"
 								>
 									{post.title}
 								</Link>
+								<span className="col-span-2 text-right hidden md:block">
+									{source && (
+										<span className="inline-block text-xs font-medium text-ink-secondary border border-line rounded-badge px-2 py-0.5">
+											{source}
+										</span>
+									)}
+								</span>
 								<span className="col-span-3 md:col-span-3 text-sm font-medium text-ink-secondary tnum text-right">
 									{published.toLocaleDateString("ja-JP")}
 								</span>
@@ -71,11 +84,59 @@ export default function Blog({
 	);
 }
 
+const QIITA_USER = "abcshotaro616";
+const ZENN_USER = "kinjyo";
+
+async function fetchQiitaPosts(): Promise<QiitaPost[]> {
+	try {
+		const res = await fetch(
+			`https://qiita.com/api/v2/users/${QIITA_USER}/items?per_page=100`,
+		);
+		if (!res.ok) return [];
+		return (await res.json()) as QiitaPost[];
+	} catch {
+		return [];
+	}
+}
+
+async function fetchZennPosts(): Promise<ZennPost[]> {
+	try {
+		const res = await fetch(
+			`https://zenn.dev/api/articles?username=${ZENN_USER}&order=latest`,
+		);
+		if (!res.ok) return [];
+		const data = (await res.json()) as { articles: ZennPost[] };
+		return data.articles ?? [];
+	} catch {
+		return [];
+	}
+}
+
 export const getStaticProps = async () => {
-	const blog: BlogPosts = getBlogs();
+	const [qiita, zenn] = await Promise.all([
+		fetchQiitaPosts(),
+		fetchZennPosts(),
+	]);
+	// 一覧表示に使うフィールドだけ残す (本文まで含めるとページデータが肥大するため)
+	const localSlim = getBlogs().map(
+		({ id, title, createdAt }) => ({ id, title, createdAt }) as BlogPost,
+	);
+	const qiitaSlim = qiita.map(
+		({ id, title, url, created_at }) =>
+			({ id, title, url, created_at }) as QiitaPost,
+	);
+	const zennSlim = zenn.map(
+		({ id, title, path, published_at }) =>
+			({ id, title, path, published_at }) as ZennPost,
+	);
+	const blog: Post[] = [...localSlim, ...qiitaSlim, ...zennSlim].sort(
+		(a, b) => getPublishedDate(b).getTime() - getPublishedDate(a).getTime(),
+	);
 	return {
 		props: {
 			blog,
 		},
+		// Qiita / Zenn の新着を再デプロイなしで反映する (1時間ごと)
+		revalidate: 3600,
 	};
 };


### PR DESCRIPTION
## Summary
Writing 一覧がローカル記事5件のみだったため、Qiita (abcshotaro616) と Zenn (kinjyo) の投稿もあわせて表示する。型定義と外部リンク判定 (`isPostWithUrl` / `isPostWithPath`) は旧バージョンの下地が残っていたので、それを使って取得部分を実装した。

## Changes
- `pages/blog/index.tsx`
  - `getStaticProps` で Qiita API / Zenn API から記事を取得し、ローカル記事とマージして日付降順で表示 (計29件)
  - `revalidate: 3600` の ISR で、新着記事を再デプロイなしで反映
  - 出所がわかるよう Qiita / Zenn バッジを行に表示 (外部記事は新しいタブで開く)
  - API 失敗時は空配列にフォールバックし、ビルドは落とさない
  - 一覧に使うフィールドだけ props に残し、ページデータ肥大 (301kB 警告) を解消
  - Zenn の `path` が `/` 始まりで URL が `zenn.dev//...` になる潜在バグを修正

## Test Plan
- [x] `biome check` / `tsc --noEmit` / `pnpm build` がローカルで通ることを確認
- [x] ビルド出力に Qiita 15件 / Zenn 9件のバッジが含まれることを確認
- [ ] Preview デプロイで /blog の一覧と外部リンクの遷移を確認