### PR TITLE
feat: /blog を /writing にリネーム

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,7 +5,7 @@ const NAV = [
 	{ href: "/about", label: "About" },
 	{ href: "/work", label: "Work" },
 	{ href: "/products", label: "Products" },
-	{ href: "/blog", label: "Writing" },
+	{ href: "/writing", label: "Writing" },
 	{ href: "/tools", label: "Tools" },
 ];
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,27 +1,42 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  async headers() {
-    return [
-      {
-        source: "/api/:path*",
-        headers: [
-          {
-            key: "Access-Control-Allow-Origin",
-            value: "*", // または、必要なオリジンを設定
-          },
-          {
-            key: "Access-Control-Allow-Methods",
-            value: "GET,POST,PUT,DELETE,OPTIONS",
-          },
-          {
-            key: "Access-Control-Allow-Headers",
-            value: "X-Requested-With, Content-Type, Accept",
-          },
-        ],
-      },
-    ];
-  },
+	reactStrictMode: true,
+	async redirects() {
+		// 旧 /blog パスからの恒久リダイレクト (外部からのリンク・検索インデックス対策)
+		return [
+			{
+				source: "/blog",
+				destination: "/writing",
+				permanent: true,
+			},
+			{
+				source: "/blog/:id",
+				destination: "/writing/:id",
+				permanent: true,
+			},
+		];
+	},
+	async headers() {
+		return [
+			{
+				source: "/api/:path*",
+				headers: [
+					{
+						key: "Access-Control-Allow-Origin",
+						value: "*", // または、必要なオリジンを設定
+					},
+					{
+						key: "Access-Control-Allow-Methods",
+						value: "GET,POST,PUT,DELETE,OPTIONS",
+					},
+					{
+						key: "Access-Control-Allow-Headers",
+						value: "X-Requested-With, Content-Type, Accept",
+					},
+				],
+			},
+		];
+	},
 };
 
 export default nextConfig;

--- a/pages/api/feed.ts
+++ b/pages/api/feed.ts
@@ -14,14 +14,14 @@ export default async function handler(
 		language: "ja",
 	});
 	const blogs = getBlogs();
-	blogs.forEach((post) => {
+	for (const post of blogs) {
 		feed.item({
 			title: post.title,
 			description: post.description,
 			date: new Date(post.createdAt),
-			url: `${process.env.URL}/blog/${post.id}`,
+			url: `${process.env.URL}/writing/${post.id}`,
 		});
-	});
+	}
 	res.statusCode = 200;
 	res.setHeader("Content-Type", "application/xml; charset=utf-8");
 	res.end(feed.xml());

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -189,7 +189,7 @@ export default function Home({
 										{String(i + 1).padStart(2, "0")}
 									</span>
 									<Link
-										href={`/blog/${post.id}`}
+										href={`/writing/${post.id}`}
 										className="col-span-9 link-draw jp-display text-lg md:text-xl font-medium text-ink-primary"
 									>
 										{post.title}
@@ -201,7 +201,7 @@ export default function Home({
 							))}
 						</ul>
 						<Link
-							href="/blog"
+							href="/writing"
 							className="col-span-12 md:col-start-4 md:col-span-9 text-sm font-medium text-ink-primary link-draw mt-2"
 						>
 							see all writing →

--- a/pages/layout.tsx
+++ b/pages/layout.tsx
@@ -24,7 +24,7 @@ export default function Layout({
 	const routeFeed = () => {
 		router.push("/api/feed");
 	};
-	const isBlogPath = router.pathname === "/blog";
+	const isBlogPath = router.pathname === "/writing";
 
 	useEffect(() => {
 		setPageClass("page-enter");

--- a/pages/writing/[id].tsx
+++ b/pages/writing/[id].tsx
@@ -71,7 +71,7 @@ export default function BlogId({ blog }: { blog: BlogPost }) {
 
 					<div className="mt-16 pt-6 border-t border-line">
 						<Link
-							href="/blog"
+							href="/writing"
 							className="text-sm font-medium text-ink-primary link-draw no-underline"
 						>
 							← Back to index
@@ -84,7 +84,7 @@ export default function BlogId({ blog }: { blog: BlogPost }) {
 }
 
 export const getStaticPaths = async () => {
-	const paths = getBlogs().map((post) => `/blog/${post.id}`);
+	const paths = getBlogs().map((post) => `/writing/${post.id}`);
 	return { paths, fallback: false };
 };
 

--- a/pages/writing/index.tsx
+++ b/pages/writing/index.tsx
@@ -12,7 +12,7 @@ function getHref(post: Post): string {
 	if (isPostWithUrl(post)) return post.url;
 	if (isPostWithPath(post))
 		return `https://zenn.dev${post.path.startsWith("/") ? "" : "/"}${post.path}`;
-	return `/blog/${post.id}`;
+	return `/writing/${post.id}`;
 }
 
 function isExternal(post: Post): boolean {


### PR DESCRIPTION
## Summary
ナビ表記は Writing なのに URL slug が /blog だったので、/writing に統一します。

※ PR #60 (Writing一覧のOGP画像) の変更ファイルと重なるため、base を feat/blog-thumbnails にした stacked PR です。#60 のマージ後に base は自動で main に切り替わります。マージ順は #60 → 本PR でお願いします。

## Changes
- pages/blog/ → pages/writing/ (一覧・記事詳細)
- 内部リンクを /writing に変更: pages/index.tsx (Topの記事リンク・View all)、components/Header.tsx (ナビ)、pages/writing/[id].tsx (戻るリンク・paths)、pages/api/feed.ts (RSSの記事URL)
- pages/layout.tsx: RSSボタンの表示判定を /writing に変更
- next.config.mjs: 旧 /blog・/blog/:id から 308 恒久リダイレクトを追加 (外部リンク・検索インデックス対策)
- pages/api/feed.ts: biome の noForEach 指摘に合わせ for...of に修正

## Test Plan
- [x] npx biome check
- [x] npx tsc --noEmit
- [x] pnpm build — /writing と /writing/[id] の生成を確認