### PR TITLE
fix: ツマジロカップの年を2024に修正

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,7 +17,7 @@ const ACHIEVEMENTS = [
 	{
 		title: "ハックツハッカソン ツマジロカップ studist賞",
 		url: "https://hackz.team/news/28VSpLaigPOw6KcqbgbVZT",
-		year: "2023",
+		year: "2024",
 	},
 	{
 		title: "ハックツハッカソン スピノカップ 最優秀賞",


### PR DESCRIPTION
## Summary
Top の Awards でツマジロカップが 2023 年表記でしたが、Doorkeeper のイベントページによると実際の開催は 2024年2月17〜18日のため修正します。

## Changes
- pages/index.tsx: ACHIEVEMENTS のツマジロカップ studist賞の year を 2023 → 2024

## Test Plan
- [x] 表示のみの変更 (文字列1箇所)