### PR TITLE
feat: 記事OGP画像を案Aデザインで生成

### DIFF
--- a/pages/api/og.tsx
+++ b/pages/api/og.tsx
@@ -1,69 +1,167 @@
 import { ImageResponse } from "@vercel/og";
-import type { NextApiRequest, NextApiResponse } from "next";
 
 export const config = {
 	runtime: "edge",
 };
 
-// デザインの調整はここがおすすめ
-// https://og-playground.vercel.app/
+const SITE = "kinjo.me";
+const AUTHOR = "金城翔太郎";
 
-export default async function handler(
-	req: NextApiRequest,
-	res: NextApiResponse,
-) {
-	const { searchParams } = new URL(req.url || "", "http://localhost");
-	const hasTitle = searchParams.has("title");
-	const title = hasTitle
-		? searchParams.get("title")?.slice(0, 100)
-		: "My default title";
-	// const title = req.query.title as string;
-	// console.log(title);
+// DESIGN.md v2 のモノクロームランプから (edge 関数のため CSS トークンを参照できずここに転記)
+const INK_900 = "#1b1a1a";
+const INK_700 = "#4e4d4c";
+const INK_500 = "#878684";
+const LINE_200 = "#dfdedd";
+const PAPER_50 = "#fafafa";
+
+// Google Fonts から必要なグリフだけを subset 取得する (Satori は woff2 非対応のため旧 UA で ttf を得る)
+async function loadNotoSansJP(
+	weight: number,
+	text: string,
+): Promise<ArrayBuffer | null> {
+	try {
+		const css = await (
+			await fetch(
+				`https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@${weight}&text=${encodeURIComponent(text)}`,
+				{
+					headers: {
+						"User-Agent":
+							"Mozilla/5.0 (Windows NT 6.1; rv:22.0) Gecko/20130405 Firefox/22.0",
+					},
+				},
+			)
+		).text();
+		const match = css.match(
+			/src: url\((.+?)\) format\('(?:opentype|truetype)'\)/,
+		);
+		if (!match) return null;
+		const res = await fetch(match[1]);
+		if (!res.ok) return null;
+		return await res.arrayBuffer();
+	} catch {
+		return null;
+	}
+}
+
+export default async function handler(req: Request) {
+	const { searchParams } = new URL(req.url);
+	const title = searchParams.get("title")?.slice(0, 80) || SITE;
+	const date = searchParams.get("date")?.slice(0, 10).replaceAll("-", ".");
+	const label = searchParams.get("label")?.slice(0, 20) || "Writing";
+
+	const subsetText = `${title}${SITE}${AUTHOR}${label}0123456789.`;
+	const [regular, bold] = await Promise.all([
+		loadNotoSansJP(400, subsetText),
+		loadNotoSansJP(700, subsetText),
+	]);
+	const fonts = [
+		...(regular
+			? [{ name: "Noto Sans JP", data: regular, weight: 400 as const }]
+			: []),
+		...(bold
+			? [{ name: "Noto Sans JP", data: bold, weight: 700 as const }]
+			: []),
+	];
+
 	return new ImageResponse(
 		<div
 			style={{
-				fontSize: 40,
-				color: "black",
-				background: "white",
 				width: "100%",
 				height: "100%",
-				padding: "50px 200px",
-				textAlign: "center",
-				justifyContent: "center",
-				alignItems: "center",
 				display: "flex",
 				flexDirection: "column",
-				position: "relative",
+				backgroundColor: PAPER_50,
+				padding: "64px 80px",
+				fontFamily: '"Noto Sans JP"',
 			}}
 		>
-			{title}
+			<div
+				style={{
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+				}}
+			>
+				<span style={{ fontSize: 34, fontWeight: 700, color: INK_900 }}>
+					{SITE}
+				</span>
+				<span
+					style={{
+						fontSize: 23,
+						fontWeight: 400,
+						color: INK_700,
+						border: `2px solid ${LINE_200}`,
+						borderRadius: 999,
+						padding: "8px 26px",
+					}}
+				>
+					{label}
+				</span>
+			</div>
 
 			<div
 				style={{
-					position: "absolute",
-					bottom: 80,
-					right: 10,
+					height: 2,
+					backgroundColor: LINE_200,
+					margin: "30px 0",
+				}}
+			/>
+
+			<div
+				style={{
+					flex: 1,
 					display: "flex",
 					alignItems: "center",
-					margin: "20px",
+					minHeight: 0,
 				}}
 			>
-				<img
-					src="https://kinjo.me/profile.jpg"
-					alt="アイコン"
+				<div
 					style={{
-						width: 60, // 明示的に幅を指定
-						height: 60, // 明示的に高さを指定
-						marginRight: 5,
-						borderRadius: "50%",
+						fontSize: 62,
+						fontWeight: 700,
+						lineHeight: 1.4,
+						color: INK_900,
+						lineClamp: 3,
 					}}
-				/>
-				<span style={{ fontSize: 32 }}>kinjo shotaro</span>
+				>
+					{title}
+				</div>
+			</div>
+
+			<div
+				style={{
+					height: 2,
+					backgroundColor: LINE_200,
+					margin: "30px 0",
+				}}
+			/>
+
+			<div
+				style={{
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "baseline",
+				}}
+			>
+				<span
+					style={{
+						fontSize: 26,
+						fontWeight: 400,
+						color: INK_500,
+						fontVariantNumeric: "tabular-nums",
+					}}
+				>
+					{date ?? ""}
+				</span>
+				<span style={{ fontSize: 26, fontWeight: 400, color: INK_700 }}>
+					{AUTHOR}
+				</span>
 			</div>
 		</div>,
 		{
 			width: 1200,
 			height: 630,
+			fonts: fonts.length > 0 ? fonts : undefined,
 		},
 	);
 }

--- a/pages/writing/[id].tsx
+++ b/pages/writing/[id].tsx
@@ -20,7 +20,7 @@ export default function BlogId({ blog }: { blog: BlogPost }) {
 				title="Blog"
 				titleTemplate={blog.title}
 				description={blog.description}
-				imgUrl={`${isDevImageUrl}/api/og?title=${encodeURIComponent(blog.title)}`}
+				imgUrl={`${isDevImageUrl}/api/og?title=${encodeURIComponent(blog.title)}&date=${blog.createdAt.slice(0, 10)}`}
 			/>
 
 			<section className="grid grid-cols-12 gap-6 lg:gap-8 pt-8">

--- a/pages/writing/index.tsx
+++ b/pages/writing/index.tsx
@@ -169,9 +169,15 @@ export const getStaticProps = async () => {
 	const blog: Post[] = await Promise.all(
 		[...localSlim, ...qiitaSlim, ...zennSlim].map(async (post) => {
 			const withImage = { ...post, image: null } as Post;
-			return isExternal(withImage)
-				? { ...withImage, image: await fetchOgImage(getHref(withImage)) }
-				: withImage;
+			if (isExternal(withImage)) {
+				return { ...withImage, image: await fetchOgImage(getHref(withImage)) };
+			}
+			// ローカル記事は自前の OGP 生成 API をサムネイルに使う
+			const local = post as BlogPost;
+			return {
+				...withImage,
+				image: `/api/og?title=${encodeURIComponent(local.title)}&date=${local.createdAt.slice(0, 10)}`,
+			};
 		}),
 	);
 	blog.sort(


### PR DESCRIPTION
## Summary
ローカル記事の OGP 画像を、デザイン案A (Index — 一覧の行を1200×630に展開) で動的生成します。DESIGN.md v2 のモノクロームランプ準拠。

## Changes
- pages/api/og.tsx: @vercel/og で案Aデザインを実装
  - 上段: kinjo.me ワードマーク + Writing チップ / 中央: タイトル (3行クランプ) / 下段: 日付 (tnum) + 金城翔太郎
  - Noto Sans JP 400/700 を Google Fonts からタイトル文字だけ subset 取得 (Satori が woff2 非対応のため旧UAで ttf を取得)。取得失敗時もフォールバックで描画継続
  - title / date / label をクエリで差し込み可能
- pages/writing/[id].tsx: og:image の URL に date パラメータを追加
- pages/writing/index.tsx: ローカル記事のサムネイル (旧 kinjo.me プレースホルダー) を /api/og 生成画像に置き換え

## Test Plan
- [x] npx biome check / npx tsc --noEmit
- [x] ローカル dev で短いタイトル・長いタイトル (3行) の PNG 生成を目視確認
- [x] pnpm build — ローカル記事 6/6 件のサムネイルが /api/og になることを確認