### PR TITLE
feat: Products一覧にサイトへのリンクを追加

### DIFF
--- a/pages/products/[slug].tsx
+++ b/pages/products/[slug].tsx
@@ -46,8 +46,8 @@ export default function ProductDetail({ product }: { product: Product }) {
 										className="link-draw text-sm font-medium text-ink-primary no-underline"
 									>
 										{product.url.includes("github.com")
-											? "GitHub →"
-											: "Try it →"}
+											? "github →"
+											: "website →"}
 									</a>
 								</dd>
 							</div>

--- a/pages/products/[slug].tsx
+++ b/pages/products/[slug].tsx
@@ -45,7 +45,9 @@ export default function ProductDetail({ product }: { product: Product }) {
 										rel="noopener noreferrer"
 										className="link-draw text-sm font-medium text-ink-primary no-underline"
 									>
-										Visit →
+										{product.url.includes("github.com")
+											? "GitHub →"
+											: "Try it →"}
 									</a>
 								</dd>
 							</div>

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -28,24 +28,29 @@ export default function Product({ products }: { products: Products }) {
 				<ul className="col-span-12 md:col-span-9 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-12">
 					{products.map((product, i) => (
 						<li key={product.slug}>
-							<Link
-								href={`/products/${product.slug}`}
-								className="block no-underline group border border-line rounded-card bg-surface-card shadow-sm hover:shadow-md transition-shadow overflow-hidden"
-							>
-								<div className="relative overflow-hidden border-b border-line aspect-[1200/630] bg-surface-sunken">
-									<Image
-										src={product.image.url}
-										alt={product.title}
-										width={product.image.width}
-										height={product.image.height}
-										className="w-full h-full object-contain"
-									/>
-								</div>
+							<div className="border border-line rounded-card bg-surface-card shadow-sm hover:shadow-md transition-shadow overflow-hidden">
+								<Link
+									href={`/products/${product.slug}`}
+									className="block no-underline"
+								>
+									<div className="relative overflow-hidden border-b border-line aspect-[1200/630] bg-surface-sunken">
+										<Image
+											src={product.image.url}
+											alt={product.title}
+											width={product.image.width}
+											height={product.image.height}
+											className="w-full h-full object-contain"
+										/>
+									</div>
+								</Link>
 								<div className="p-5">
 									<div className="flex items-baseline justify-between gap-4">
-										<p className="jp-display text-xl md:text-2xl font-medium text-ink-primary">
+										<Link
+											href={`/products/${product.slug}`}
+											className="jp-display text-xl md:text-2xl font-medium text-ink-primary no-underline link-draw"
+										>
 											{product.title}
-										</p>
+										</Link>
 										<span className="text-sm font-medium text-ink-secondary tnum shrink-0">
 											{year(product.publishedAt)}
 										</span>
@@ -55,8 +60,20 @@ export default function Product({ products }: { products: Products }) {
 											{product.description}
 										</p>
 									)}
+									{product.url && (
+										<a
+											href={product.url}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="inline-block text-sm font-medium text-ink-primary link-draw no-underline mt-3"
+										>
+											{product.url.includes("github.com")
+												? "GitHub →"
+												: "Try it →"}
+										</a>
+									)}
 								</div>
-							</Link>
+							</div>
 						</li>
 					))}
 				</ul>

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -68,8 +68,8 @@ export default function Product({ products }: { products: Products }) {
 											className="inline-block text-sm font-medium text-ink-primary link-draw no-underline mt-3"
 										>
 											{product.url.includes("github.com")
-												? "GitHub →"
-												: "Try it →"}
+												? "github →"
+												: "website →"}
 										</a>
 									)}
 								</div>


### PR DESCRIPTION
## Summary
URL があるプロダクトのサイトへ一覧から直接飛べるように、カードに外部リンクを追加します。

## Changes
- pages/products/index.tsx: カード構造を変更 (全体 Link → 画像/タイトルが Link) し、url を持つプロダクトに「website →」リンクを表示。GitHub リポジトリの場合は「github →」表記。ネストした \<a\> を避けるための構造変更です
- pages/products/[slug].tsx: サイドバーの「Visit →」を同じ表記に統一

## 対象
rafutabi / favarite-text-site / psynaut / mapmemo (LIFF) / 印算 (PR #67)

## Test Plan
- [x] npx biome check / npx tsc --noEmit / pnpm build