### PR TITLE
feat: サイト全体のラベルを日本語化

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,12 +2,12 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 
 const NAV = [
-	{ href: "/about", label: "About" },
-	{ href: "/work", label: "Work" },
-	{ href: "/products", label: "Products" },
-	{ href: "/writing", label: "Writing" },
-	{ href: "/talks", label: "Talks" },
-	{ href: "/tools", label: "Tools" },
+	{ href: "/about", label: "自己紹介" },
+	{ href: "/work", label: "職歴" },
+	{ href: "/products", label: "プロダクト" },
+	{ href: "/writing", label: "記事" },
+	{ href: "/talks", label: "登壇" },
+	{ href: "/tools", label: "ツール" },
 ];
 
 export const Header: React.FC = () => {

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -4,10 +4,10 @@ import Layout from "./layout";
 
 export default function AboutPage({ about }: { about: About }) {
 	return (
-		<Layout title="About">
+		<Layout title="自己紹介">
 			<SeoHead
-				title="About"
-				titleTemplate="About"
+				title="自己紹介"
+				titleTemplate="金城翔太郎 / Shotaro Kinjo"
 				description="About me"
 				imgUrl="/favicon.ico"
 			/>
@@ -17,19 +17,21 @@ export default function AboutPage({ about }: { about: About }) {
 					<p className="text-sm font-medium text-ink-secondary mb-6">Profile</p>
 					<dl className="space-y-4 text-base">
 						<div>
-							<dt className="text-sm font-medium text-ink-secondary">Name</dt>
+							<dt className="text-sm font-medium text-ink-secondary">名前</dt>
 							<dd className="font-semibold text-ink-primary mt-1">
 								{about.name}
 							</dd>
 						</div>
 						<div>
-							<dt className="text-sm font-medium text-ink-secondary">Birth</dt>
+							<dt className="text-sm font-medium text-ink-secondary">
+								生年月日
+							</dt>
 							<dd className="font-semibold text-ink-primary mt-1 tnum">
 								{about.birth}
 							</dd>
 						</div>
 						<div>
-							<dt className="text-sm font-medium text-ink-secondary">Origin</dt>
+							<dt className="text-sm font-medium text-ink-secondary">出身</dt>
 							<dd className="font-semibold text-ink-primary mt-1">
 								{about.origin}
 							</dd>

--- a/pages/products/[slug].tsx
+++ b/pages/products/[slug].tsx
@@ -8,10 +8,10 @@ import Layout from "../layout";
 
 export default function ProductDetail({ product }: { product: Product }) {
 	return (
-		<Layout title={product.title} eyebrow="Products">
+		<Layout title={product.title} eyebrow="プロダクト">
 			<SeoHead
-				title="Products"
-				titleTemplate={product.title}
+				title={product.title}
+				titleTemplate="金城翔太郎 / Shotaro Kinjo"
 				description={product.description ?? product.title}
 				imgUrl={product.image.url}
 			/>
@@ -20,24 +20,22 @@ export default function ProductDetail({ product }: { product: Product }) {
 				<aside className="col-span-12 md:col-span-3">
 					<dl className="space-y-4 text-base">
 						<div>
-							<dt className="text-sm font-medium text-ink-secondary">
-								Published
-							</dt>
+							<dt className="text-sm font-medium text-ink-secondary">公開日</dt>
 							<dd className="font-semibold text-ink-primary mt-1 tnum">
 								{formatDate(product.publishedAt)}
 							</dd>
 						</div>
 						<div>
-							<dt className="text-sm font-medium text-ink-secondary">
-								Updated
-							</dt>
+							<dt className="text-sm font-medium text-ink-secondary">更新日</dt>
 							<dd className="font-semibold text-ink-primary mt-1 tnum">
 								{formatDate(product.updatedAt)}
 							</dd>
 						</div>
 						{product.url && (
 							<div>
-								<dt className="text-sm font-medium text-ink-secondary">Link</dt>
+								<dt className="text-sm font-medium text-ink-secondary">
+									リンク
+								</dt>
 								<dd className="mt-1">
 									<a
 										href={product.url}
@@ -46,8 +44,8 @@ export default function ProductDetail({ product }: { product: Product }) {
 										className="link-draw text-sm font-medium text-ink-primary no-underline"
 									>
 										{product.url.includes("github.com")
-											? "github →"
-											: "website →"}
+											? "GitHub →"
+											: "サイトを見る →"}
 									</a>
 								</dd>
 							</div>
@@ -82,7 +80,7 @@ export default function ProductDetail({ product }: { product: Product }) {
 							href="/products"
 							className="text-sm font-medium text-ink-primary link-draw no-underline"
 						>
-							← Back to index
+							← プロダクト一覧へ
 						</Link>
 					</div>
 				</article>

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -9,19 +9,19 @@ const year = (iso: string) => new Date(iso).getFullYear();
 
 export default function Product({ products }: { products: Products }) {
 	return (
-		<Layout title="Products">
+		<Layout title="プロダクト">
 			<SeoHead
-				title="Products"
-				titleTemplate="プロダクト一覧"
-				description="Products List"
+				title="プロダクト"
+				titleTemplate="金城翔太郎 / Shotaro Kinjo"
+				description="個人でつくったプロダクトの一覧です。"
 				imgUrl="/favicon.ico"
 			/>
 
 			<section className="grid grid-cols-12 gap-6 lg:gap-8 pt-8">
 				<header className="col-span-12 md:col-span-3">
-					<p className="text-sm font-medium text-ink-secondary">Index</p>
+					<p className="text-sm font-medium text-ink-secondary">一覧</p>
 					<p className="tnum text-sm font-medium text-ink-secondary mt-2">
-						{String(products.length).padStart(2, "0")} entries
+						{products.length}件
 					</p>
 				</header>
 
@@ -68,8 +68,8 @@ export default function Product({ products }: { products: Products }) {
 											className="inline-block text-sm font-medium text-ink-primary link-draw no-underline mt-3"
 										>
 											{product.url.includes("github.com")
-												? "github →"
-												: "website →"}
+												? "GitHub →"
+												: "サイトを見る →"}
 										</a>
 									)}
 								</div>

--- a/pages/talks/index.tsx
+++ b/pages/talks/index.tsx
@@ -25,19 +25,19 @@ const year = (iso: string) => new Date(iso).getFullYear();
 
 export default function Talks({ talks }: { talks: Talk[] }) {
 	return (
-		<Layout title="Talks">
+		<Layout title="登壇">
 			<SeoHead
-				title="Talks"
-				titleTemplate="Top"
-				description="登壇・発表の一覧ページです"
+				title="登壇"
+				titleTemplate="金城翔太郎 / Shotaro Kinjo"
+				description="イベントでの登壇と発表の一覧です。"
 				imgUrl="/favicon.ico"
 			/>
 
 			<section className="grid grid-cols-12 gap-6 lg:gap-8 pt-8">
 				<header className="col-span-12 md:col-span-3">
-					<p className="text-sm font-medium text-ink-secondary">Index</p>
+					<p className="text-sm font-medium text-ink-secondary">一覧</p>
 					<p className="tnum text-sm font-medium text-ink-secondary mt-2">
-						{String(talks.length).padStart(2, "0")} entries
+						{talks.length}件
 					</p>
 				</header>
 
@@ -108,7 +108,7 @@ export default function Talks({ talks }: { talks: Talk[] }) {
 						rel="noopener noreferrer"
 						className="link-draw text-ink-primary"
 					>
-						see all slides on Speaker Deck →
+						Speaker Deck で他のスライドを見る →
 					</a>
 				</p>
 			</section>

--- a/pages/tools/compress.tsx
+++ b/pages/tools/compress.tsx
@@ -124,12 +124,12 @@ export default function CompressPage() {
 	return (
 		<>
 			<SeoHead
-				title="Image Compress"
-				titleTemplate="Image Compress"
+				title="画像を圧縮する"
+				titleTemplate="金城翔太郎 / Shotaro Kinjo"
 				description="画像をブラウザ内で圧縮・形式変換 (WebP / AVIF / JPG / PNG)"
 				imgUrl="/favicon.ico"
 			/>
-			<Layout title="Compress">
+			<Layout title="画像を圧縮する" eyebrow="ツール">
 				<div className="mb-6">
 					<p className="text-sm text-ink-secondary">
 						画像はあなたのブラウザ内だけで処理されます。サーバーには送信されません。

--- a/pages/tools/crop.tsx
+++ b/pages/tools/crop.tsx
@@ -129,12 +129,12 @@ export default function CropPage() {
 	return (
 		<>
 			<SeoHead
-				title="Image Crop"
-				titleTemplate="Image Crop"
+				title="画像を切り抜く"
+				titleTemplate="金城翔太郎 / Shotaro Kinjo"
 				description="サムネイル・OGP・SNSアイコン用の画像を素早くトリミング"
 				imgUrl="/favicon.ico"
 			/>
-			<Layout title="Image crop">
+			<Layout title="画像を切り抜く" eyebrow="ツール">
 				<div className="mb-6">
 					<p className="text-sm text-ink-secondary">
 						画像はあなたのブラウザ内だけで処理されます。サーバーには送信されません。

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -12,14 +12,14 @@ type Tool = {
 const TOOLS: Tool[] = [
 	{
 		slug: "compress",
-		title: "Image Compress",
+		title: "画像を圧縮する",
 		description:
 			"画像をブラウザ内で圧縮・形式変換。WebP / AVIF / JPG / PNG。リアルタイムに削減率を確認。",
 		tags: ["image", "compress", "convert"],
 	},
 	{
 		slug: "crop",
-		title: "Image Crop",
+		title: "画像を切り抜く",
 		description:
 			"OGP / SNS アイコン / 16:9 などのプリセットで素早くトリミング。ローカル完結。",
 		tags: ["image", "crop", "ogp"],
@@ -28,19 +28,19 @@ const TOOLS: Tool[] = [
 
 export default function ToolsIndex() {
 	return (
-		<Layout title="Tools">
+		<Layout title="ツール">
 			<SeoHead
-				title="Tools"
-				titleTemplate="Tools"
+				title="ツール"
+				titleTemplate="金城翔太郎 / Shotaro Kinjo"
 				description="ブラウザ内で完結する自作ユーティリティツール。"
 				imgUrl="/favicon.ico"
 			/>
 
 			<section className="grid grid-cols-12 gap-6 lg:gap-8 pt-8">
 				<header className="col-span-12 md:col-span-3">
-					<p className="text-sm font-medium text-ink-secondary">Index</p>
+					<p className="text-sm font-medium text-ink-secondary">一覧</p>
 					<p className="tnum text-sm font-medium text-ink-secondary mt-2">
-						{String(TOOLS.length).padStart(2, "0")} tools
+						{TOOLS.length}件
 					</p>
 					<p className="text-base text-ink-secondary mt-4 leading-relaxed">
 						ブラウザ内で完結する自作の小ユーティリティ。サーバー送信なし。

--- a/pages/work/[slug].tsx
+++ b/pages/work/[slug].tsx
@@ -10,10 +10,10 @@ import Layout from "../layout";
 export default function WorkDetail({ work }: { work: Work }) {
 	const toc = renderToc(work.body);
 	return (
-		<Layout title={work.title} eyebrow="Work">
+		<Layout title={work.title} eyebrow="職歴">
 			<SeoHead
-				title="Work"
-				titleTemplate={work.title}
+				title={work.title}
+				titleTemplate="金城翔太郎 / Shotaro Kinjo"
 				description={work.description}
 				imgUrl="/favicon.ico"
 			/>
@@ -34,7 +34,7 @@ export default function WorkDetail({ work }: { work: Work }) {
 							{work.position.length > 0 && (
 								<div>
 									<dt className="text-sm font-medium text-ink-secondary">
-										Role
+										担当
 									</dt>
 									<dd className="font-semibold text-ink-primary mt-1">
 										{work.position.join(" / ")}
@@ -70,7 +70,7 @@ export default function WorkDetail({ work }: { work: Work }) {
 						{toc.length >= 4 && (
 							<div>
 								<p className="text-sm font-medium text-ink-secondary mb-2">
-									Contents
+									目次
 								</p>
 								<TableOfContents toc={toc} />
 							</div>
@@ -92,7 +92,7 @@ export default function WorkDetail({ work }: { work: Work }) {
 							href="/work"
 							className="text-sm font-medium text-ink-primary link-draw no-underline"
 						>
-							← Back to index
+							← 職歴一覧へ
 						</Link>
 					</div>
 				</article>

--- a/pages/work/index.tsx
+++ b/pages/work/index.tsx
@@ -16,19 +16,19 @@ const monogram = (title: string) =>
 
 export default function Work({ works }: { works: WorkWithLogo[] }) {
 	return (
-		<Layout title="Work">
+		<Layout title="職歴">
 			<SeoHead
-				title="Work"
-				titleTemplate="Work"
-				description="Work List"
+				title="職歴"
+				titleTemplate="金城翔太郎 / Shotaro Kinjo"
+				description="これまでに関わった会社と案件の一覧です。"
 				imgUrl="/favicon.ico"
 			/>
 
 			<section className="grid grid-cols-12 gap-6 lg:gap-8 pt-8">
 				<header className="col-span-12 md:col-span-3">
-					<p className="text-sm font-medium text-ink-secondary">Index</p>
+					<p className="text-sm font-medium text-ink-secondary">一覧</p>
 					<p className="tnum text-sm font-medium text-ink-secondary mt-2">
-						{String(works.length).padStart(2, "0")} entries
+						{works.length}件
 					</p>
 				</header>
 
@@ -77,7 +77,7 @@ export default function Work({ works }: { works: WorkWithLogo[] }) {
 								</p>
 								<p className="mt-2">
 									<span className="inline-block text-xs font-medium text-ink-secondary border border-line rounded-badge px-2 py-0.5">
-										{work.toAt ? "closed" : "ongoing"}
+										{work.toAt ? "終了" : "継続中"}
 									</span>
 								</p>
 								{work.link && (
@@ -87,7 +87,7 @@ export default function Work({ works }: { works: WorkWithLogo[] }) {
 										rel="noopener noreferrer"
 										className="text-sm font-medium text-ink-primary link-draw mt-2 inline-block no-underline"
 									>
-										company →
+										会社サイト →
 									</a>
 								)}
 							</div>


### PR DESCRIPTION
## Summary
UI に英語ラベルが多かったので、ナビゲーションと各ページの見出し・メタラベルを日本語にします。

## Changes
- components/Header.tsx: ナビを 自己紹介 / 職歴 / プロダクト / 記事 / 登壇 / ツール に
- pages/work/index.tsx: 見出し「職歴」、Index → 一覧、NN entries → N件、company → → 会社サイト →、ongoing/closed → 継続中/終了
- pages/work/[slug].tsx: Role → 担当、Contents → 目次、← Back to index → ← 職歴一覧へ、eyebrow → 職歴
- pages/products/index.tsx / [slug].tsx: 見出し「プロダクト」、Published/Updated/Link → 公開日/更新日/リンク、website → → サイトを見る →、← プロダクト一覧へ
- pages/talks/index.tsx: 見出し「登壇」、Speaker Deck へのリンク文言を日本語に
- pages/tools/*: 見出し「ツール」、Image Compress / Image Crop → 画像を圧縮する / 画像を切り抜く
- pages/about.tsx: 見出し「自己紹介」、Name/Birth/Origin → 名前/生年月日/出身
- 各ページの SEO タイトルを日本語に統一し、titleTemplate を「金城翔太郎 / Shotaro Kinjo」に揃えた (Work List などの英語 description も日本語に)

## 英語のまま残したもの
固有名詞 (Qiita / Zenn / GitHub / Speaker Deck / kinjo.me)、技術名、フッターの著作権表記とSNS名。

## 備考
Top (pages/index.tsx) は PR #72、記事ページ (pages/writing/*) は PR #71 で日本語化しています。3本合わせてサイト全体がカバーされます。

## Test Plan
- [x] npx biome check / npx tsc --noEmit / pnpm build