### PR TITLE
fix: モバイルでヘッダーのナビが2行になるのを修正

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -27,12 +27,13 @@ export const Header: React.FC = () => {
 				>
 					kinjo.me
 				</Link>
-				<nav className="flex flex-wrap items-center gap-x-1 gap-y-1 -mx-2 md:mx-0 md:justify-end md:gap-x-4">
+				{/* モバイルでは折り返さず横スクロールさせる (2行になるのを防ぐ) */}
+				<nav className="flex items-center gap-x-1 flex-nowrap overflow-x-auto scrollbar-none -mx-6 px-6 md:mx-0 md:px-0 md:overflow-visible md:justify-end md:gap-x-4">
 					{NAV.map((item) => (
 						<Link
 							key={item.href}
 							href={item.href}
-							className={`text-sm font-medium no-underline rounded-button px-2 md:px-3 py-1.5 transition-colors ${
+							className={`text-xs md:text-sm font-medium no-underline rounded-button px-1.5 md:px-3 py-1.5 whitespace-nowrap shrink-0 transition-colors ${
 								isActive(item.href)
 									? "bg-surface-sunken text-ink-primary"
 									: "text-ink-secondary hover:text-ink-primary hover:bg-surface-sunken"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,323 +6,309 @@
 @tailwind utilities;
 
 @layer base {
-	html {
-		background-color: var(--surface-page);
-		color: var(--text-primary);
-		font-family: var(--font-body);
-		font-size: var(--size-md);
-		line-height: var(--leading-normal);
-		font-feature-settings: "kern", "liga", "calt";
-		-webkit-font-smoothing: antialiased;
-		-moz-osx-font-smoothing: grayscale;
-		text-rendering: optimizeLegibility;
-		overflow-x: clip;
-	}
+  html {
+    background-color: var(--surface-page);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    font-size: var(--size-md);
+    line-height: var(--leading-normal);
+    font-feature-settings: "kern", "liga", "calt";
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    overflow-x: clip;
+  }
 
-	body {
-		background-color: var(--surface-page);
-		color: var(--text-primary);
-		overflow-x: clip;
-	}
+  body {
+    background-color: var(--surface-page);
+    color: var(--text-primary);
+    overflow-x: clip;
+  }
 
-	h1,
-	h2,
-	h3,
-	h4 {
-		font-family: var(--font-display);
-		line-height: var(--leading-snug);
-		color: var(--text-heading);
-		font-weight: 700;
-	}
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: var(--font-display);
+    line-height: var(--leading-snug);
+    color: var(--text-heading);
+    font-weight: 700;
+  }
 
-	/* JP 見出し (Noto Sans JP 明示) */
-	.jp-display {
-		font-family: var(--font-jp-display);
-		font-weight: 700;
-	}
+  /* JP 見出し (Noto Sans JP 明示) */
+  .jp-display {
+    font-family: var(--font-jp-display);
+    font-weight: 700;
+  }
 
-	a {
-		color: var(--link);
-		text-decoration: underline;
-		text-decoration-thickness: 1px;
-		text-underline-offset: 0.2em;
-		transition: color var(--duration-fast) var(--ease-standard);
-	}
+  a {
+    color: var(--link);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.2em;
+    transition: color var(--duration-fast) var(--ease-standard);
+  }
 
-	a:hover {
-		color: var(--link-hover);
-	}
+  a:hover {
+    color: var(--link-hover);
+  }
 
-	/* Focus ring: 2px solid primary, offset 2px (DESIGN.md §2.3) */
-	:focus-visible {
-		outline: 2px solid var(--focus-ring);
-		outline-offset: 2px;
-	}
+  /* Focus ring: 2px solid primary, offset 2px (DESIGN.md §2.3) */
+  :focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+  }
 
-	:disabled {
-		opacity: 0.4;
-	}
+  :disabled {
+    opacity: 0.4;
+  }
 
-	::selection {
-		background-color: var(--surface-inverse);
-		color: var(--text-on-inverse);
-	}
+  ::selection {
+    background-color: var(--surface-inverse);
+    color: var(--text-on-inverse);
+  }
 
-	/* Label: 通常ケースの muted ラベル (DESIGN.md §11 A4)。旧 uppercase マイクロラベルは廃止 */
-	.small-caps {
-		font-family: var(--font-body);
-		letter-spacing: var(--tracking-normal);
-	}
+  /* Label: 通常ケースの muted ラベル (DESIGN.md §11 A4)。旧 uppercase マイクロラベルは廃止 */
+  .small-caps {
+    font-family: var(--font-body);
+    letter-spacing: var(--tracking-normal);
+  }
 
-	/* Tabular numerals for index numbers */
-	.tnum {
-		font-family: var(--font-body);
-		font-variant-numeric: tabular-nums;
-	}
+  /* Tabular numerals for index numbers */
+  .tnum {
+    font-family: var(--font-body);
+    font-variant-numeric: tabular-nums;
+  }
 }
 
 /* ---- Animations (restrained — DESIGN.md §7) ---- */
 @keyframes fadeUp {
-	from {
-		opacity: 0;
-		transform: translateY(6px);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes drawRule {
-	from {
-		transform: scaleX(0);
-	}
-	to {
-		transform: scaleX(1);
-	}
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
 }
 
 .page-enter {
-	animation: fadeUp var(--duration-slow) var(--ease-editorial) forwards;
+  animation: fadeUp var(--duration-slow) var(--ease-editorial) forwards;
 }
 
 .page-enter > * {
-	animation: fadeUp var(--duration-slow) var(--ease-editorial) both;
+  animation: fadeUp var(--duration-slow) var(--ease-editorial) both;
 }
 
-.page-enter > *:nth-child(1) {
-	animation-delay: 0ms;
-}
-.page-enter > *:nth-child(2) {
-	animation-delay: 60ms;
-}
-.page-enter > *:nth-child(3) {
-	animation-delay: 120ms;
-}
-.page-enter > *:nth-child(4) {
-	animation-delay: 180ms;
-}
-.page-enter > *:nth-child(5) {
-	animation-delay: 240ms;
-}
-.page-enter > *:nth-child(6) {
-	animation-delay: 300ms;
-}
-.page-enter > *:nth-child(n + 7) {
-	animation-delay: 360ms;
-}
+.page-enter > *:nth-child(1) { animation-delay: 0ms; }
+.page-enter > *:nth-child(2) { animation-delay: 60ms; }
+.page-enter > *:nth-child(3) { animation-delay: 120ms; }
+.page-enter > *:nth-child(4) { animation-delay: 180ms; }
+.page-enter > *:nth-child(5) { animation-delay: 240ms; }
+.page-enter > *:nth-child(6) { animation-delay: 300ms; }
+.page-enter > *:nth-child(n + 7) { animation-delay: 360ms; }
 
 .ink-settle {
-	animation: fadeUp var(--duration-slow) var(--ease-editorial) both;
+  animation: fadeUp var(--duration-slow) var(--ease-editorial) both;
 }
 
 /* v1 のテクスチャ背景は廃止。プレーンなサーフェスのみ */
 .home-plain-paper {
-	background-color: var(--surface-page);
+  background-color: var(--surface-page);
 }
 
 /* Decorative rule that animates in */
 .rule-line {
-	display: block;
-	height: 1px;
-	background-color: var(--border-strong);
-	transform-origin: left center;
-	animation: drawRule var(--duration-slow) var(--ease-editorial) forwards;
+  display: block;
+  height: 1px;
+  background-color: var(--border-strong);
+  transform-origin: left center;
+  animation: drawRule var(--duration-slow) var(--ease-editorial) forwards;
 }
 
 /* ---- Prose (markdown body) ---- */
 .prose {
-	color: var(--text-primary);
-	font-family: var(--font-body);
-	font-size: var(--size-md);
-	line-height: 1.8;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: var(--size-md);
+  line-height: 1.8;
 }
 
 .prose p {
-	margin-top: 1em;
-	margin-bottom: 1em;
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 .prose h2 {
-	font-weight: 700;
-	font-size: var(--size-2xl);
-	line-height: var(--leading-snug);
-	margin-top: 2.5em;
-	margin-bottom: 0.6em;
-	padding-top: 1em;
-	border-top: 1px solid var(--rule-color);
+  font-weight: 700;
+  font-size: var(--size-2xl);
+  line-height: var(--leading-snug);
+  margin-top: 2.5em;
+  margin-bottom: 0.6em;
+  padding-top: 1em;
+  border-top: 1px solid var(--rule-color);
 }
 
 .prose h3 {
-	font-weight: 700;
-	font-size: var(--size-xl);
-	line-height: var(--leading-snug);
-	margin-top: 2em;
-	margin-bottom: 0.6em;
+  font-weight: 700;
+  font-size: var(--size-xl);
+  line-height: var(--leading-snug);
+  margin-top: 2em;
+  margin-bottom: 0.6em;
 }
 
 .prose h4 {
-	font-weight: 700;
-	font-size: var(--size-lg);
-	margin-top: 1.6em;
-	margin-bottom: 0.4em;
+  font-weight: 700;
+  font-size: var(--size-lg);
+  margin-top: 1.6em;
+  margin-bottom: 0.4em;
 }
 
 .prose a {
-	color: var(--link);
-	text-decoration: underline;
-	text-decoration-thickness: 1px;
-	text-underline-offset: 0.2em;
-	font-weight: 500;
+  color: var(--link);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+  font-weight: 500;
 }
 
 .prose a:hover {
-	color: var(--link-hover);
+  color: var(--link-hover);
 }
 
 .prose blockquote {
-	border-left: 2px solid var(--border-strong);
-	padding-left: 1em;
-	font-style: normal;
-	color: var(--text-secondary);
-	margin: 1.5em 0;
+  border-left: 2px solid var(--border-strong);
+  padding-left: 1em;
+  font-style: normal;
+  color: var(--text-secondary);
+  margin: 1.5em 0;
 }
 
 .prose ul,
 .prose ol {
-	padding-left: 1.4em;
-	margin: 1em 0;
+  padding-left: 1.4em;
+  margin: 1em 0;
 }
 
 .prose ul {
-	list-style: disc;
+  list-style: disc;
 }
 
 .prose ol {
-	list-style: decimal;
-	font-variant-numeric: tabular-nums;
+  list-style: decimal;
+  font-variant-numeric: tabular-nums;
 }
 
 .prose li {
-	margin: 0.4em 0;
+  margin: 0.4em 0;
 }
 
 .prose li::marker {
-	color: var(--text-tertiary);
+  color: var(--text-tertiary);
 }
 
 .prose code {
-	background: var(--surface-sunken);
-	padding: 0.12em 0.4em;
-	font-family: var(--font-mono);
-	font-size: 0.92em;
-	font-weight: 500;
-	border: 1px solid var(--border-default);
-	border-radius: var(--radius-sm);
+  background: var(--surface-sunken);
+  padding: 0.12em 0.4em;
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  font-weight: 500;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
 }
 
 .prose pre {
-	background: var(--surface-inverse);
-	color: var(--text-on-inverse);
-	padding: 1.2em 1.4em;
-	overflow-x: auto;
-	font-family: var(--font-mono);
-	font-size: 0.9em;
-	line-height: 1.6;
-	margin: 1.5em 0;
-	border-radius: var(--radius-md);
+  background: var(--surface-inverse);
+  color: var(--text-on-inverse);
+  padding: 1.2em 1.4em;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  line-height: 1.6;
+  margin: 1.5em 0;
+  border-radius: var(--radius-md);
 }
 
 .prose pre code {
-	background: transparent;
-	border: none;
-	padding: 0;
-	color: inherit;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
 }
 
 .prose hr {
-	border: none;
-	border-top: 1px solid var(--rule-color);
-	margin: 3em 0;
+  border: none;
+  border-top: 1px solid var(--rule-color);
+  margin: 3em 0;
 }
 
 .prose img {
-	margin: 2em 0;
-	border: 1px solid var(--border-default);
-	border-radius: var(--radius-md);
+  margin: 2em 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
 }
 
 .prose table {
-	border-collapse: collapse;
-	width: 100%;
-	margin: 1.5em 0;
-	font-size: 0.95em;
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1.5em 0;
+  font-size: 0.95em;
 }
 
 .prose th,
 .prose td {
-	border-bottom: 1px solid var(--border-default);
-	padding: 0.6em 0.8em;
-	text-align: left;
+  border-bottom: 1px solid var(--border-default);
+  padding: 0.6em 0.8em;
+  text-align: left;
 }
 
 .prose th {
-	font-weight: 600;
-	font-size: 0.9em;
-	color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.9em;
+  color: var(--text-secondary);
 }
 
 /* Link hover: drawn underline */
 .link-draw {
-	position: relative;
-	text-decoration: none;
-	display: inline-block;
+  position: relative;
+  text-decoration: none;
+  display: inline-block;
 }
 
 .link-draw::after {
-	content: "";
-	position: absolute;
-	left: 0;
-	bottom: -2px;
-	width: 100%;
-	height: 1px;
-	background-color: currentColor;
-	transform: scaleX(0);
-	transform-origin: right center;
-	transition: transform var(--duration-normal) var(--ease-editorial);
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 1px;
+  background-color: currentColor;
+  transform: scaleX(0);
+  transform-origin: right center;
+  transition: transform var(--duration-normal) var(--ease-editorial);
 }
 
 .link-draw:hover::after {
-	transform: scaleX(1);
-	transform-origin: left center;
+  transform: scaleX(1);
+  transform-origin: left center;
 }
 
 /* 横スクロールするナビでスクロールバーを隠す */
 .scrollbar-none {
-	scrollbar-width: none;
-	-ms-overflow-style: none;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
 .scrollbar-none::-webkit-scrollbar {
-	display: none;
+  display: none;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,299 +6,323 @@
 @tailwind utilities;
 
 @layer base {
-  html {
-    background-color: var(--surface-page);
-    color: var(--text-primary);
-    font-family: var(--font-body);
-    font-size: var(--size-md);
-    line-height: var(--leading-normal);
-    font-feature-settings: "kern", "liga", "calt";
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
-    overflow-x: clip;
-  }
+	html {
+		background-color: var(--surface-page);
+		color: var(--text-primary);
+		font-family: var(--font-body);
+		font-size: var(--size-md);
+		line-height: var(--leading-normal);
+		font-feature-settings: "kern", "liga", "calt";
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		text-rendering: optimizeLegibility;
+		overflow-x: clip;
+	}
 
-  body {
-    background-color: var(--surface-page);
-    color: var(--text-primary);
-    overflow-x: clip;
-  }
+	body {
+		background-color: var(--surface-page);
+		color: var(--text-primary);
+		overflow-x: clip;
+	}
 
-  h1,
-  h2,
-  h3,
-  h4 {
-    font-family: var(--font-display);
-    line-height: var(--leading-snug);
-    color: var(--text-heading);
-    font-weight: 700;
-  }
+	h1,
+	h2,
+	h3,
+	h4 {
+		font-family: var(--font-display);
+		line-height: var(--leading-snug);
+		color: var(--text-heading);
+		font-weight: 700;
+	}
 
-  /* JP 見出し (Noto Sans JP 明示) */
-  .jp-display {
-    font-family: var(--font-jp-display);
-    font-weight: 700;
-  }
+	/* JP 見出し (Noto Sans JP 明示) */
+	.jp-display {
+		font-family: var(--font-jp-display);
+		font-weight: 700;
+	}
 
-  a {
-    color: var(--link);
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 0.2em;
-    transition: color var(--duration-fast) var(--ease-standard);
-  }
+	a {
+		color: var(--link);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.2em;
+		transition: color var(--duration-fast) var(--ease-standard);
+	}
 
-  a:hover {
-    color: var(--link-hover);
-  }
+	a:hover {
+		color: var(--link-hover);
+	}
 
-  /* Focus ring: 2px solid primary, offset 2px (DESIGN.md §2.3) */
-  :focus-visible {
-    outline: 2px solid var(--focus-ring);
-    outline-offset: 2px;
-  }
+	/* Focus ring: 2px solid primary, offset 2px (DESIGN.md §2.3) */
+	:focus-visible {
+		outline: 2px solid var(--focus-ring);
+		outline-offset: 2px;
+	}
 
-  :disabled {
-    opacity: 0.4;
-  }
+	:disabled {
+		opacity: 0.4;
+	}
 
-  ::selection {
-    background-color: var(--surface-inverse);
-    color: var(--text-on-inverse);
-  }
+	::selection {
+		background-color: var(--surface-inverse);
+		color: var(--text-on-inverse);
+	}
 
-  /* Label: 通常ケースの muted ラベル (DESIGN.md §11 A4)。旧 uppercase マイクロラベルは廃止 */
-  .small-caps {
-    font-family: var(--font-body);
-    letter-spacing: var(--tracking-normal);
-  }
+	/* Label: 通常ケースの muted ラベル (DESIGN.md §11 A4)。旧 uppercase マイクロラベルは廃止 */
+	.small-caps {
+		font-family: var(--font-body);
+		letter-spacing: var(--tracking-normal);
+	}
 
-  /* Tabular numerals for index numbers */
-  .tnum {
-    font-family: var(--font-body);
-    font-variant-numeric: tabular-nums;
-  }
+	/* Tabular numerals for index numbers */
+	.tnum {
+		font-family: var(--font-body);
+		font-variant-numeric: tabular-nums;
+	}
 }
 
 /* ---- Animations (restrained — DESIGN.md §7) ---- */
 @keyframes fadeUp {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+	from {
+		opacity: 0;
+		transform: translateY(6px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
 }
 
 @keyframes drawRule {
-  from {
-    transform: scaleX(0);
-  }
-  to {
-    transform: scaleX(1);
-  }
+	from {
+		transform: scaleX(0);
+	}
+	to {
+		transform: scaleX(1);
+	}
 }
 
 .page-enter {
-  animation: fadeUp var(--duration-slow) var(--ease-editorial) forwards;
+	animation: fadeUp var(--duration-slow) var(--ease-editorial) forwards;
 }
 
 .page-enter > * {
-  animation: fadeUp var(--duration-slow) var(--ease-editorial) both;
+	animation: fadeUp var(--duration-slow) var(--ease-editorial) both;
 }
 
-.page-enter > *:nth-child(1) { animation-delay: 0ms; }
-.page-enter > *:nth-child(2) { animation-delay: 60ms; }
-.page-enter > *:nth-child(3) { animation-delay: 120ms; }
-.page-enter > *:nth-child(4) { animation-delay: 180ms; }
-.page-enter > *:nth-child(5) { animation-delay: 240ms; }
-.page-enter > *:nth-child(6) { animation-delay: 300ms; }
-.page-enter > *:nth-child(n + 7) { animation-delay: 360ms; }
+.page-enter > *:nth-child(1) {
+	animation-delay: 0ms;
+}
+.page-enter > *:nth-child(2) {
+	animation-delay: 60ms;
+}
+.page-enter > *:nth-child(3) {
+	animation-delay: 120ms;
+}
+.page-enter > *:nth-child(4) {
+	animation-delay: 180ms;
+}
+.page-enter > *:nth-child(5) {
+	animation-delay: 240ms;
+}
+.page-enter > *:nth-child(6) {
+	animation-delay: 300ms;
+}
+.page-enter > *:nth-child(n + 7) {
+	animation-delay: 360ms;
+}
 
 .ink-settle {
-  animation: fadeUp var(--duration-slow) var(--ease-editorial) both;
+	animation: fadeUp var(--duration-slow) var(--ease-editorial) both;
 }
 
 /* v1 のテクスチャ背景は廃止。プレーンなサーフェスのみ */
 .home-plain-paper {
-  background-color: var(--surface-page);
+	background-color: var(--surface-page);
 }
 
 /* Decorative rule that animates in */
 .rule-line {
-  display: block;
-  height: 1px;
-  background-color: var(--border-strong);
-  transform-origin: left center;
-  animation: drawRule var(--duration-slow) var(--ease-editorial) forwards;
+	display: block;
+	height: 1px;
+	background-color: var(--border-strong);
+	transform-origin: left center;
+	animation: drawRule var(--duration-slow) var(--ease-editorial) forwards;
 }
 
 /* ---- Prose (markdown body) ---- */
 .prose {
-  color: var(--text-primary);
-  font-family: var(--font-body);
-  font-size: var(--size-md);
-  line-height: 1.8;
+	color: var(--text-primary);
+	font-family: var(--font-body);
+	font-size: var(--size-md);
+	line-height: 1.8;
 }
 
 .prose p {
-  margin-top: 1em;
-  margin-bottom: 1em;
+	margin-top: 1em;
+	margin-bottom: 1em;
 }
 
 .prose h2 {
-  font-weight: 700;
-  font-size: var(--size-2xl);
-  line-height: var(--leading-snug);
-  margin-top: 2.5em;
-  margin-bottom: 0.6em;
-  padding-top: 1em;
-  border-top: 1px solid var(--rule-color);
+	font-weight: 700;
+	font-size: var(--size-2xl);
+	line-height: var(--leading-snug);
+	margin-top: 2.5em;
+	margin-bottom: 0.6em;
+	padding-top: 1em;
+	border-top: 1px solid var(--rule-color);
 }
 
 .prose h3 {
-  font-weight: 700;
-  font-size: var(--size-xl);
-  line-height: var(--leading-snug);
-  margin-top: 2em;
-  margin-bottom: 0.6em;
+	font-weight: 700;
+	font-size: var(--size-xl);
+	line-height: var(--leading-snug);
+	margin-top: 2em;
+	margin-bottom: 0.6em;
 }
 
 .prose h4 {
-  font-weight: 700;
-  font-size: var(--size-lg);
-  margin-top: 1.6em;
-  margin-bottom: 0.4em;
+	font-weight: 700;
+	font-size: var(--size-lg);
+	margin-top: 1.6em;
+	margin-bottom: 0.4em;
 }
 
 .prose a {
-  color: var(--link);
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 0.2em;
-  font-weight: 500;
+	color: var(--link);
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.2em;
+	font-weight: 500;
 }
 
 .prose a:hover {
-  color: var(--link-hover);
+	color: var(--link-hover);
 }
 
 .prose blockquote {
-  border-left: 2px solid var(--border-strong);
-  padding-left: 1em;
-  font-style: normal;
-  color: var(--text-secondary);
-  margin: 1.5em 0;
+	border-left: 2px solid var(--border-strong);
+	padding-left: 1em;
+	font-style: normal;
+	color: var(--text-secondary);
+	margin: 1.5em 0;
 }
 
 .prose ul,
 .prose ol {
-  padding-left: 1.4em;
-  margin: 1em 0;
+	padding-left: 1.4em;
+	margin: 1em 0;
 }
 
 .prose ul {
-  list-style: disc;
+	list-style: disc;
 }
 
 .prose ol {
-  list-style: decimal;
-  font-variant-numeric: tabular-nums;
+	list-style: decimal;
+	font-variant-numeric: tabular-nums;
 }
 
 .prose li {
-  margin: 0.4em 0;
+	margin: 0.4em 0;
 }
 
 .prose li::marker {
-  color: var(--text-tertiary);
+	color: var(--text-tertiary);
 }
 
 .prose code {
-  background: var(--surface-sunken);
-  padding: 0.12em 0.4em;
-  font-family: var(--font-mono);
-  font-size: 0.92em;
-  font-weight: 500;
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-sm);
+	background: var(--surface-sunken);
+	padding: 0.12em 0.4em;
+	font-family: var(--font-mono);
+	font-size: 0.92em;
+	font-weight: 500;
+	border: 1px solid var(--border-default);
+	border-radius: var(--radius-sm);
 }
 
 .prose pre {
-  background: var(--surface-inverse);
-  color: var(--text-on-inverse);
-  padding: 1.2em 1.4em;
-  overflow-x: auto;
-  font-family: var(--font-mono);
-  font-size: 0.9em;
-  line-height: 1.6;
-  margin: 1.5em 0;
-  border-radius: var(--radius-md);
+	background: var(--surface-inverse);
+	color: var(--text-on-inverse);
+	padding: 1.2em 1.4em;
+	overflow-x: auto;
+	font-family: var(--font-mono);
+	font-size: 0.9em;
+	line-height: 1.6;
+	margin: 1.5em 0;
+	border-radius: var(--radius-md);
 }
 
 .prose pre code {
-  background: transparent;
-  border: none;
-  padding: 0;
-  color: inherit;
+	background: transparent;
+	border: none;
+	padding: 0;
+	color: inherit;
 }
 
 .prose hr {
-  border: none;
-  border-top: 1px solid var(--rule-color);
-  margin: 3em 0;
+	border: none;
+	border-top: 1px solid var(--rule-color);
+	margin: 3em 0;
 }
 
 .prose img {
-  margin: 2em 0;
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-md);
+	margin: 2em 0;
+	border: 1px solid var(--border-default);
+	border-radius: var(--radius-md);
 }
 
 .prose table {
-  border-collapse: collapse;
-  width: 100%;
-  margin: 1.5em 0;
-  font-size: 0.95em;
+	border-collapse: collapse;
+	width: 100%;
+	margin: 1.5em 0;
+	font-size: 0.95em;
 }
 
 .prose th,
 .prose td {
-  border-bottom: 1px solid var(--border-default);
-  padding: 0.6em 0.8em;
-  text-align: left;
+	border-bottom: 1px solid var(--border-default);
+	padding: 0.6em 0.8em;
+	text-align: left;
 }
 
 .prose th {
-  font-weight: 600;
-  font-size: 0.9em;
-  color: var(--text-secondary);
+	font-weight: 600;
+	font-size: 0.9em;
+	color: var(--text-secondary);
 }
 
 /* Link hover: drawn underline */
 .link-draw {
-  position: relative;
-  text-decoration: none;
-  display: inline-block;
+	position: relative;
+	text-decoration: none;
+	display: inline-block;
 }
 
 .link-draw::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -2px;
-  width: 100%;
-  height: 1px;
-  background-color: currentColor;
-  transform: scaleX(0);
-  transform-origin: right center;
-  transition: transform var(--duration-normal) var(--ease-editorial);
+	content: "";
+	position: absolute;
+	left: 0;
+	bottom: -2px;
+	width: 100%;
+	height: 1px;
+	background-color: currentColor;
+	transform: scaleX(0);
+	transform-origin: right center;
+	transition: transform var(--duration-normal) var(--ease-editorial);
 }
 
 .link-draw:hover::after {
-  transform: scaleX(1);
-  transform-origin: left center;
+	transform: scaleX(1);
+	transform-origin: left center;
+}
+
+/* 横スクロールするナビでスクロールバーを隠す */
+.scrollbar-none {
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+}
+
+.scrollbar-none::-webkit-scrollbar {
+	display: none;
 }


### PR DESCRIPTION
## Summary
ナビを日本語にしたことで項目が横幅に収まらず、モバイルで2行に折り返していました。1行に収まるようにします。

## Changes
- components/Header.tsx
  - ナビを折り返し禁止 (flex-nowrap) + 横スクロール (overflow-x-auto) に変更。項目が増えても2行にならない
  - モバイルのみ文字サイズ 14px → 12px、左右パディング 8px → 6px に縮小。実測で必要幅 368px → 308px になり、375px 幅の端末でもスクロールなしで収まる
  - 画面端まで自然にスクロールできるよう -mx-6 px-6 で全幅化 (md 以上は従来どおり)
- styles/globals.css: .scrollbar-none ユーティリティを追加 (横スクロールバーの非表示)

## 検証
ローカルで 320 / 375 / 390 / 768px 幅を実測:

| 幅 | ナビ行数 | ページ横スクロール |
|---|---|---|
| 320px | 1行 (ナビ内で横スクロール) | なし |
| 375px | 1行 (スクロールなしで収まる) | なし |
| 390px | 1行 (スクロールなしで収まる) | なし |
| 768px | 1行 | なし |

## Test Plan
- [x] npx biome check / npx tsc --noEmit / pnpm build
- [x] 上記4サイズでナビが1行、かつページ全体の横スクロールが発生しないことを確認